### PR TITLE
Use a decorator to restrict admin required routes - reduce code duplication

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask
 from flask_restful import Api
 from flask_jwt_extended import JWTManager, jwt_refresh_token_required, create_access_token, get_jwt_identity
 from flask_cors import CORS
+from resources.admin_required import admin_required
 from models.user import UserModel
 from models.property import PropertyModel
 from models.revoked_tokens import RevokedTokensModel

--- a/resources/admin_required.py
+++ b/resources/admin_required.py
@@ -1,0 +1,14 @@
+from flask_jwt_extended import jwt_required, get_jwt_claims
+
+def admin_required(func):
+    @jwt_required
+    def check_admin_wrapper(*args, **kwargs):
+        #check if is_admin exist. If not discontinue function
+        claims = get_jwt_claims() 
+        if not claims['is_admin']:
+            return {'message': "Admin Access Required"}, 401
+
+        return func(*args, **kwargs)
+
+    return check_admin_wrapper
+

--- a/resources/email.py
+++ b/resources/email.py
@@ -1,7 +1,7 @@
 from flask import Flask
 from flask_restful import Resource, reqparse
 from flask_mail import Message
-from flask_jwt_extended import jwt_required, get_jwt_claims
+from resources.admin_required import admin_required
 import app
 from models.user import UserModel
 
@@ -11,14 +11,8 @@ class Email(Resource):
     parser.add_argument('title') 
     parser.add_argument('body') 
 
-    @jwt_required
+    @admin_required
     def post(self):
-        # check if is_admin exist if not discontinue function
-        claims = get_jwt_claims()
-        
-        if not claims['is_admin']:
-            return {'Message', "Admin Access Required"}, 401
-
         data = Email.parser.parse_args()
 
         if not data.userid or not data.title or not data.body:
@@ -36,9 +30,4 @@ class Email(Resource):
 
         app.mail.send(message)
         return {"Message": "Message Sent"}
-
-
-
-
-        
 

--- a/resources/property.py
+++ b/resources/property.py
@@ -1,6 +1,6 @@
 import json
 from flask_restful import Resource, reqparse
-from flask_jwt_extended import jwt_required, get_jwt_claims
+from resources.admin_required import admin_required
 from db import db
 from models.property import PropertyModel
 from models.user import UserModel
@@ -32,14 +32,8 @@ class Properties(Resource):
         # print(dict(zip(row.keys(), row)) for row in result)
         return {'properties': [property._asdict() for property in db.session.query(PropertyModel.id, PropertyModel.name, PropertyModel.address, PropertyModel.tenants, PropertyModel.dateAdded, UserModel.fullName.label('propertyManager')).join(UserModel).all()]}
     
-    @jwt_required
+    @admin_required
     def post(self):
-        #check if is_admin exist if not discontinue function
-        claims = get_jwt_claims() 
-        
-        if not claims['is_admin']:
-            return {'message': "Admin Access Required"}, 401
-
         data = Properties.parser.parse_args()
 
         if PropertyModel.find_by_name(data["name"]):
@@ -56,14 +50,8 @@ class Properties(Resource):
 
 class ArchiveProperty(Resource):
 
-    @jwt_required
+    @admin_required
     def post(self, id):
-        #check if is_admin exist if not discontinue function
-        claims = get_jwt_claims() 
-        
-        if not claims['is_admin']:
-            return {'message': "Admin Access Required"}, 401
-
         property = PropertyModel.find_by_id(id)
         if(not property):
             return{'message': 'Property cannot be archived'}, 400
@@ -89,40 +77,24 @@ class Property(Resource):
     parser.add_argument('dateAdded')
     parser.add_argument('archived')
 
-    @jwt_required
+    @admin_required
     def get(self, name):
-        claims = get_jwt_claims() 
-
-        if not claims['is_admin']:
-            return {'message': "Admin Access Required"}, 401
-
         rentalProperty = PropertyModel.find_by_name(name)
 
         if rentalProperty:
             return rentalProperty.json()
         return {'message': 'Property not found'}, 404
     
-    @jwt_required
+    @admin_required
     def delete(self, name):
-        claims = get_jwt_claims() 
-
-        if not claims['is_admin']:
-            return {'message': "Admin Access Required"}, 401
-
         property = PropertyModel.find_by_name(name)
         if property:
             property.delete_from_db()
             return {'message': 'Property deleted.'}
         return {'message': 'Property not found.'}, 404
 
-    @jwt_required
+    @admin_required
     def put(self, name):
-
-        claims = get_jwt_claims() 
-
-        if not claims['is_admin']:
-            return {'message': "Admin Access Required"}, 401
-
         data = Properties.parser.parse_args()
         rentalProperty = PropertyModel.find_by_name(name)
 


### PR DESCRIPTION
Most routes in Dwellingly require admin privileges to access them. The code to pull in the JWT and check for the admin role is redundant and exists across many routes. 

This PR introduces a custom decorator that can be used as follows:
```  
    @admin_required
    def post(self):
        # process request
```
 
Old code (for reference):
```
    @jwt_required
    def post(self):
        #check if is_admin exist if not discontinue function
        claims = get_jwt_claims() 
        
        if not claims['is_admin']:
            return {'message': "Admin Access Required"}, 401

        # process request
```