### PR TITLE
Allow for backend API to be deployed on Heroku

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,7 @@ Werkzeug = "==1.0.0"
 "zope.interface" = "==4.7.1"
 Flask-mail = "==0.9.1"
 Flask-Cors = "*"
+psycopg2 = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a3e39907e19267d437b2f715db586ac621a7bb12279f76efaad7635b0d7a4c8f"
+            "sha256": "d0804146be09f8c257ab57a44d5e4e1e1788507ea0d4e5d1412b8425582a6c65"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -154,6 +154,25 @@
             ],
             "index": "pypi",
             "version": "==1.1.1"
+        },
+        "psycopg2": {
+            "hashes": [
+                "sha256:132efc7ee46a763e68a815f4d26223d9c679953cd190f1f218187cb60decf535",
+                "sha256:2327bf42c1744a434ed8ed0bbaa9168cac7ee5a22a9001f6fc85c33b8a4a14b7",
+                "sha256:27c633f2d5db0fc27b51f1b08f410715b59fa3802987aec91aeb8f562724e95c",
+                "sha256:2c0afb40cfb4d53487ee2ebe128649028c9a78d2476d14a67781e45dc287f080",
+                "sha256:2df2bf1b87305bd95eb3ac666ee1f00a9c83d10927b8144e8e39644218f4cf81",
+                "sha256:440a3ea2c955e89321a138eb7582aa1d22fe286c7d65e26a2c5411af0a88ae72",
+                "sha256:6a471d4d2a6f14c97a882e8d3124869bc623f3df6177eefe02994ea41fd45b52",
+                "sha256:6b306dae53ec7f4f67a10942cf8ac85de930ea90e9903e2df4001f69b7833f7e",
+                "sha256:a0984ff49e176062fcdc8a5a2a670c9bb1704a2f69548bce8f8a7bad41c661bf",
+                "sha256:ac5b23d0199c012ad91ed1bbb971b7666da651c6371529b1be8cbe2a7bf3c3a9",
+                "sha256:acf56d564e443e3dea152efe972b1434058244298a94348fc518d6dd6a9fb0bb",
+                "sha256:d3b29d717d39d3580efd760a9a46a7418408acebbb784717c90d708c9ed5f055",
+                "sha256:f7d46240f7a1ae1dd95aab38bd74f7428d46531f69219954266d669da60c0818"
+            ],
+            "index": "pypi",
+            "version": "==2.8.5"
         },
         "pyjwt": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -58,7 +58,7 @@ def create_app():
 
 
 app = create_app()
-api = Api(app)
+api = Api(app, prefix="/api/")
 
 @app.before_first_request
 def check_for_admins():

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ def create_app():
     app = Flask(__name__)
 
     #config DataBase
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///data.db'
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv("DATABASE_URL", default = 'sqlite:///data.db')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['PROPAGATE_EXCEPTIONS'] = True
     app.secret_key = 'dwellingly' #Replace with Random Hash

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.4
+python-3.8.2


### PR DESCRIPTION
An example is currently running at https://dwellinglypdxapi.herokuapp.com/api/ (e.g., https://dwellinglypdxapi.herokuapp.com/api/properties).

Note that all endpoints are now prefixed under `/api/`.

I've pulled in psql as a dependency as Heroku does not support sqllite: https://devcenter.heroku.com/articles/sqlite3.