### PR TITLE
add Python version requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ NOTE: Database is SQLite3 via SQLAlchemy
 1. Clone the repo (`git clone https://github.com/codeforpdx/dwellinglybackend.git`)
 2. Install Python ( https://realpython.com/installing-python/ )
 3. Install pipenv: `pip3 install --user pipenv`.
+   - Python version 3.6 or higher is required
 4. Seed the database
    - Run: `python seed_db.py`
    - To re-seed the database from scratch, delete data.db before running the script


### PR DESCRIPTION
On my Linux machine, the latest version of Python in the repos is 3.5, but 3.6+ is required to install the dependencies for the backend.