### PR TITLE
Update tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,20 +223,38 @@ Authorization Bearer < JWT access token >
 
 ```
 
+
+#### ENDPOINT: TICKETS
+
+| method | route              | action (all actions require user to be logged in)   |
+| :----- | :----------------- | :-------------------------------------------------- |
+| POST   | `/tickets/`        | Creates a new ticket                                |
+| GET    | `/tickets/`        | Gets all tickets                                    |
+| GET    | `/tickets/:id`     | Gets a single ticket                                |
+| PUT    | `/tickets/:id`     | Updates a single ticket                             | 
+| DELETE | `/tickets/:id`     | Deletes a single ticket                             |
+
+```javascript
+    id: 1,
+    issue: 'Property Damage',
+    tenant: 'Renty McRenter',
+    senderID: 1,
+    tenantID: 2,
+    assignedUserID: 4,
+    sender: "user1 tester",
+    assigned: "Mr. Sir",
+    status: "new",
+    urgency: "Low",
+    opened: "01-Jul-2020 (21:29)",
+    updated: "01-Jul-2020 (22:20)",
+    minsPastUpdate: 745,
+    notes: [
+        {
+            id: 2,
+            ticketid: 1,
+            created: "01-Jul-2020 (21:29:10.086958)",
+            text: "Tenant has over 40 cats.",
+            user: "user2 tester"
+        },
+    ]
 ```
-  id: 'K-0089ttxqQX-2',
-issue: 'Property Damage',
-tenant: {
-  address: 'Magnolia Park, Unit #2',
-  name: 'Alex Alder',
-  number: '503-555-1234'
-   },
-  sender: {
-  name: 'Tom Smith',
-  number: '541-123-4567'
-  },
-  sent: new Date('2017/12/19').toString(),
-  status: 'New',
-  urgency: 'Low',
-  notes: []
-  ```

--- a/app.py
+++ b/app.py
@@ -66,6 +66,8 @@ def create_routes(app):
     api.add_resource(UserAccessRefresh, '/refresh')
     api.add_resource(Tenants, '/tenants', '/tenants/<int:tenant_id>')
     api.add_resource(EmergencyContacts, '/emergencycontacts', '/emergencycontacts/<int:id>')
+    api.add_resource(Tickets, '/tickets')
+    api.add_resource(Ticket, '/tickets/<int:id>')
 
 
 def check_for_admins():

--- a/models/tickets.py
+++ b/models/tickets.py
@@ -50,6 +50,10 @@ class TicketModel(db.Model):
         assignedUserData = UserModel.find_by_id(self.assignedUser)
         assignedUser = "{} {}".format(assignedUserData.firstName, assignedUserData.lastName)
 
+        dateTimeStatusChange = datetime.strptime(self.updated, "%d-%b-%Y (%H:%M)")
+        dateTimeNow = datetime.now()
+        minsPastUpdate = int((dateTimeNow - dateTimeStatusChange).total_seconds() / 60)
+
         return {
             'id': self.id,
             'issue':self.issue,
@@ -62,6 +66,7 @@ class TicketModel(db.Model):
             'opened': self.opened,
             'updated':self.updated,
             'status': self.status,
+            'minsPastUpdate': minsPastUpdate,
             'urgency': self.urgency,
             'notes': message_notes
         }

--- a/resources/tickets.py
+++ b/resources/tickets.py
@@ -35,46 +35,38 @@ class Ticket(Resource):
     def put(self, id):
         data = Ticket.parser.parse_args()
         ticket = TicketModel.find_by_id(id)
-        updated = False
-        dateTime = datetime.now()
 
         if ticket:
             #variable statements allow for only updated fields to be transmitted
             if(data.sender):
                 ticket.sender = data.sender
-                updated = True
 
             if(data.tenant):
                 ticket.tenant = data.tenant
-                updated = True
 
             if(data.assignedUser):
                 ticket.assignedUser = data.assignedUser
-                updated = True
 
             if(data.status):
-                ticket.status = data.status
-                updated = True
+                updated = not (ticket.status == data.status)
+                if updated:
+                    ticket.status = data.status
+                    dateTime = datetime.now()
+                    timestamp = dateTime.strftime("%d-%b-%Y (%H:%M)")
+                    ticket.updated = timestamp
 
             if(data.urgency):
                 ticket.urgency = data.urgency
-                updated = True
 
             if(data.issue):
                 ticket.issue = data.issue
-                updated = True
 
             if(data.note):
                 note = NotesModel(id, data.note, ticket.sender)
-                updated = True
                 try:
                     note.save_to_db()
                 except:
                     return {'Message': 'An Error Has Occured'}, 500
-
-            if updated:
-                timestamp = dateTime.strftime("%d-%b-%Y (%H:%M)")
-                ticket.updated = timestamp
 
             try:
                 ticket.save_to_db()


### PR DESCRIPTION
The frontend tickets dashboard module needs information about age of tickets relative to the most recent status change. Since the datetime info coming from the backend is formatted, it is difficult to calculate deltas on the frontend. Please update the /tickets/ endpoint to expose the following data points for each ticket:

Date of ticket creation
Date the ticket changed status
Time since last change in status

To Do:

- [x] modify the "updated" property in the ticket model. It is a date string that updates when the ticket's status changes
- [x] create a "minsPastUpdate" property in the ticket model. It is an integer that represents the number of minutes that have passed since the status was last updated