### PR TITLE
Create reset password feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,7 +74,7 @@ def create_routes(app):
     api.add_resource(Leases, '/lease')
     api.add_resource(Tickets, '/tickets')
     api.add_resource(Ticket, '/tickets/<int:id>')
-    api.add_resource(ForgotPassword, '/forgot_password')
+    api.add_resource(ForgotPassword, '/forgot_password', '/forgot_password/<string:token>')
 
 def check_for_admins():
     errorMsg = (

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from models.tenant import TenantModel
 from models.tenant_staff_link import StaffTenantLink
 from models.revoked_tokens import RevokedTokensModel
 from resources.user import UserRegister, User, UserLogin, ArchiveUser, UsersRole, UserAccessRefresh, UserRoles
+from resources.forgot_password import ForgotPassword
 from resources.property import Properties, Property, ArchiveProperty
 from resources.tenants import Tenants
 from resources.emergency_contacts import EmergencyContacts
@@ -74,7 +75,7 @@ def create_routes(app):
     api.add_resource(Leases, '/lease')
     api.add_resource(Tickets, '/tickets')
     api.add_resource(Ticket, '/tickets/<int:id>')
-
+    api.add_resource(ForgotPassword, '/forgot_password')
 
 def check_for_admins():
     errorMsg = (

--- a/app.py
+++ b/app.py
@@ -51,7 +51,6 @@ def config_app(app):
     # app.config['MAIL_PASSWORD'] = os.environ['EMAIL_PASSWORD']
     # app.config['MAIL_DEFAULT_SENDER'] = 'noreply@dwellingly.com'
     app.config['MAIL_MAX_EMAILS'] = 3
-    app.config['MAIL_SUPPRESS_SEND'] = False #same as testing
     app.config['MAIL_ASCII_ATTACHMENTS'] = False
 
 

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ from models.tenant import TenantModel
 from models.tenant_staff_link import StaffTenantLink
 from models.revoked_tokens import RevokedTokensModel
 from resources.user import UserRegister, User, UserLogin, ArchiveUser, UsersRole, UserAccessRefresh, UserRoles
-from resources.forgot_password import ForgotPassword
+from resources.reset_password import ResetPassword
 from resources.property import Properties, Property, ArchiveProperty
 from resources.tenants import Tenants
 from resources.emergency_contacts import EmergencyContacts
@@ -74,7 +74,7 @@ def create_routes(app):
     api.add_resource(Leases, '/lease')
     api.add_resource(Tickets, '/tickets')
     api.add_resource(Ticket, '/tickets/<int:id>')
-    api.add_resource(ForgotPassword, '/forgot_password', '/forgot_password/<string:token>')
+    api.add_resource(ResetPassword, '/reset-password', '/reset-password/<string:token>')
 
 def check_for_admins():
     errorMsg = (

--- a/models/user.py
+++ b/models/user.py
@@ -1,7 +1,10 @@
 from datetime import datetime, timedelta
+import time
+import jwt
 from db import db
 from enum import Enum
 from models.base_model import BaseModel
+from flask import current_app
 
 class RoleEnum(Enum):
     PENDING = 0
@@ -42,7 +45,15 @@ class UserModel(BaseModel):
         self.lastActive = datetime.utcnow()
         db.session.commit()
 
-    def json(self): 
+    def reset_password_token(self):
+        ten_minutes = 600
+        return jwt.encode(
+                {'reset_password': self.id, 'exp': time.time() + ten_minutes},
+                current_app.secret_key,
+                algorithm='HS256'
+            ).decode('utf-8')
+
+    def json(self):
         return {
             'id': self.id,
             'firstName': self.firstName,

--- a/resources/email.py
+++ b/resources/email.py
@@ -6,17 +6,17 @@ from models.user import UserModel
 
 class Email(Resource):
     parser = reqparse.RequestParser()
-    parser.add_argument('userid', required=True)
-    parser.add_argument('title', required=True)
+    parser.add_argument('user_id', required=True)
+    parser.add_argument('subject', required=True)
     parser.add_argument('body', required=True)
 
     @admin_required
     def post(self):
         data = Email.parser.parse_args()
 
-        message = Message(data.title, sender="noreply@codeforpdx.org", body=data.body )
+        message = Message(data.subject, sender="noreply@codeforpdx.org", body=data.body )
 
-        user = UserModel.find_by_id(data.userid)
+        user = UserModel.find_by_id(data.user_id)
         message.recipients = [user.email]
 
         current_app.mail.send(message)

--- a/resources/email.py
+++ b/resources/email.py
@@ -20,10 +20,7 @@ class Email(Resource):
         message = Message(data.title, sender="noreply@codeforpdx.org", body=data.body )
         
         user = UserModel.find_by_id(data.userid)
-        if user.email:
-            message.recipients = [user.email] 
-        else:
-            return {'Message': 'Bad Request'}, 400
+        message.recipients = [user.email] 
 
         current_app.mail.send(message)
         return {"Message": "Message Sent"}

--- a/resources/email.py
+++ b/resources/email.py
@@ -31,3 +31,7 @@ class Email(Resource):
         app.mail.send(message)
         return {"Message": "Message Sent"}
 
+
+    @staticmethod
+    def send_reset_password_msg(user):
+        pass

--- a/resources/email.py
+++ b/resources/email.py
@@ -17,8 +17,6 @@ class Email(Resource):
         if not data.userid or not data.title or not data.body:
             return {'Message': 'Bad Request'}, 400
 
-        #TODO add feature to send to multiple emails
-    
         message = Message(data.title, sender="noreply@codeforpdx.org", body=data.body )
         
         user = UserModel.find_by_id(data.userid)

--- a/resources/email.py
+++ b/resources/email.py
@@ -6,21 +6,18 @@ from models.user import UserModel
 
 class Email(Resource):
     parser = reqparse.RequestParser()
-    parser.add_argument('userid')
-    parser.add_argument('title') 
-    parser.add_argument('body') 
+    parser.add_argument('userid', required=True)
+    parser.add_argument('title', required=True)
+    parser.add_argument('body', required=True)
 
     @admin_required
     def post(self):
         data = Email.parser.parse_args()
 
-        if not data.userid or not data.title or not data.body:
-            return {'Message': 'Bad Request'}, 400
-
         message = Message(data.title, sender="noreply@codeforpdx.org", body=data.body )
-        
+
         user = UserModel.find_by_id(data.userid)
-        message.recipients = [user.email] 
+        message.recipients = [user.email]
 
         current_app.mail.send(message)
         return {"Message": "Message Sent"}

--- a/resources/email.py
+++ b/resources/email.py
@@ -5,7 +5,8 @@ from resources.admin_required import admin_required
 from models.user import UserModel
 
 class Email(Resource):
-    NO_REPLY = 'noreply@codeforpdx.org'
+    NO_REPLY = 'noreply@codeforpdx.org' # Should this be dwellingly address?
+
     parser = reqparse.RequestParser()
     parser.add_argument('user_id', required=True)
     parser.add_argument('subject', required=True)
@@ -26,7 +27,7 @@ class Email(Resource):
     @staticmethod
     def send_reset_password_msg(user):
         token = user.reset_password_token()
-        msg = Message('Reset password', sender=Email.NO_REPLY, recipients=[user.email])
+        msg = Message('Reset password for Dwellingly', sender=Email.NO_REPLY, recipients=[user.email])
         msg.body = render_template('emails/reset_msg.txt', user=user, token=token)
         msg.html = render_template('emails/reset_msg.html', user=user, token=token)
 

--- a/resources/email.py
+++ b/resources/email.py
@@ -1,8 +1,7 @@
-from flask import Flask
+from flask import Flask, current_app
 from flask_restful import Resource, reqparse
 from flask_mail import Message
 from resources.admin_required import admin_required
-import app
 from models.user import UserModel
 
 class Email(Resource):
@@ -28,7 +27,7 @@ class Email(Resource):
         else:
             return {'Message': 'Bad Request'}, 400
 
-        app.mail.send(message)
+        current_app.mail.send(message)
         return {"Message": "Message Sent"}
 
 

--- a/resources/forgot_password.py
+++ b/resources/forgot_password.py
@@ -1,0 +1,16 @@
+from flask_restful import Resource, reqparse
+from models.user import UserModel
+
+
+class ForgotPassword(Resource):
+    parser = reqparse.RequestParser()
+    parser.add_argument('email',type=str,required=True,help="This field cannot be blank.")
+
+    def post(self):
+        data = ForgotPassword.parser.parse_args()
+        user = UserModel.find_by_email(data['email'])
+
+        if user:
+            return user.json(), 200
+        else:
+            return {"message": "Unable to find email"}, 400

--- a/resources/forgot_password.py
+++ b/resources/forgot_password.py
@@ -5,7 +5,7 @@ from resources.email import Email
 
 class ForgotPassword(Resource):
     parser = reqparse.RequestParser()
-    parser.add_argument('email',type=str,required=True,help="This field cannot be blank.")
+    parser.add_argument('email', required=True)
 
     def post(self):
         data = ForgotPassword.parser.parse_args()
@@ -13,6 +13,6 @@ class ForgotPassword(Resource):
 
         if user:
             Email.send_reset_password_msg(user)
-            return user.json(), 200
+            return {"message": "Email sent"}, 200
         else:
-            return {"message": "Unable to find email"}, 400
+            return {"message": "Invalid email"}, 400

--- a/resources/forgot_password.py
+++ b/resources/forgot_password.py
@@ -16,3 +16,11 @@ class ForgotPassword(Resource):
             return {"message": "Email sent"}, 200
         else:
             return {"message": "Invalid email"}, 400
+
+    def get(self, token):
+        user = UserModel.validate_reset_password(token)
+
+        if user:
+            return {'message': 'Valid token', 'user_id': user.id}, 200
+        else:
+            return {'message': 'Expired token'}, 422

--- a/resources/forgot_password.py
+++ b/resources/forgot_password.py
@@ -1,5 +1,6 @@
 from flask_restful import Resource, reqparse
 from models.user import UserModel
+from resources.email import Email
 
 
 class ForgotPassword(Resource):
@@ -11,6 +12,7 @@ class ForgotPassword(Resource):
         user = UserModel.find_by_email(data['email'])
 
         if user:
+            Email.send_reset_password_msg(user)
             return user.json(), 200
         else:
             return {"message": "Unable to find email"}, 400

--- a/resources/reset_password.py
+++ b/resources/reset_password.py
@@ -3,12 +3,12 @@ from models.user import UserModel
 from resources.email import Email
 
 
-class ForgotPassword(Resource):
+class ResetPassword(Resource):
     parser = reqparse.RequestParser()
     parser.add_argument('email', required=True)
 
     def post(self):
-        data = ForgotPassword.parser.parse_args()
+        data = ResetPassword.parser.parse_args()
         user = UserModel.find_by_email(data['email'])
 
         if user:

--- a/templates/emails/reset_msg.html
+++ b/templates/emails/reset_msg.html
@@ -2,10 +2,10 @@
 
 <p>To reset your password click on the following link:
 
-<a href="{{ url_for('forgotpassword', token=token, _method='GET', _external=True) }}"> Reset password link</a></p>
+<a href="{{ url_for('resetpassword', token=token, _method='GET', _external=True) }}"> Reset password link</a></p>
 
 <p>Alternatively, you can paste the following link in your browser's address bar:</p>
-<p>{{ url_for('forgotpassword', token=token, _method='GET', _external=True) }}</p>
+<p>{{ url_for('resetpassword', token=token, _method='GET', _external=True) }}</p>
 <p> If you have not requested a password reset simply ignore this message.</p>
 
 

--- a/templates/emails/reset_msg.html
+++ b/templates/emails/reset_msg.html
@@ -1,0 +1,13 @@
+<p>Hello {{ user.firstName }},</p>
+
+<p>To reset your password click on the following link:
+
+<a href="{{ url_for('forgotpassword', token=token, _method='GET', _external=True) }}"> Reset password link</a></p>
+
+<p>Alternatively, you can paste the following link in your browser's address bar:</p>
+<p>{{ url_for('forgotpassword', token=token, _method='GET', _external=True) }}</p>
+<p> If you have not requested a password reset simply ignore this message.</p>
+
+
+<p>Best,</p>
+<p>Team Dwellinlgy.</p>

--- a/templates/emails/reset_msg.txt
+++ b/templates/emails/reset_msg.txt
@@ -2,7 +2,7 @@ Hello {{ user.firstName }},
 
 To reset your password click on the following link:
 
-{{ url_for('forgotpassword', token=token, _method='GET', _external=True) }}
+{{ url_for('resetpassword', token=token, _method='GET', _external=True) }}
 
 If you have not requested a password reset simply ignore this message.
 

--- a/templates/emails/reset_msg.txt
+++ b/templates/emails/reset_msg.txt
@@ -1,0 +1,10 @@
+Hello {{ user.firstName }},
+
+To reset your password click on the following link:
+
+{{ url_for('forgotpassword', token=token, _method='GET', _external=True) }}
+
+If you have not requested a password reset simply ignore this message.
+
+Best,
+Team Dwellinlgy.

--- a/tests/integration/test_forgot_password.py
+++ b/tests/integration/test_forgot_password.py
@@ -10,34 +10,25 @@ class TestForgotPassword:
     def test_request_with_invalid_params(self):
         response = self.client.post('/api/forgot_password')
         assert is_valid(response, 400)
-        assert response.json == {'message': {'email': 'This field cannot be blank.'}}
 
-    def test_response_with_invalid_email(self):
+    def test_request_with_invalid_email(self):
         response = self.client.post('/api/forgot_password', json={'email': 'invalid@example.org'})
         assert is_valid(response, 400)
-        assert response.json == {'message': 'Unable to find email'}
+        assert response.json == {'message': 'Invalid email'}
 
-    def test_response_with_valid_email(self):
+    @patch.object(Email, 'send_reset_password_msg')
+    def test_request_with_valid_email(self, send_reset_email):
         user = UserModel.find_by_id(1)
         response = self.client.post('/api/forgot_password', json={'email': user.email})
 
         assert is_valid(response, 200)
-        assert response.json == user.json()
+        assert response.json == {"message": "Email sent"}
+        send_reset_email.assert_called_once_with(user)
+
 
     @patch.object(Email, 'send_reset_password_msg')
-    def test_reset_password_email_sent(self, stubbed_reset_password_method):
-        user = UserModel.find_by_id(1)
-
-        response = self.client.post('/api/forgot_password', json={'email': user.email})
-
-        stubbed_reset_password_method.assert_called_once_with(user)
-        assert is_valid(response, 200)
-
-    @patch.object(Email, 'send_reset_password_msg')
-    def test_reset_password_email_is_not_sent_when_invalid_user(self, stubbed_reset_password_method):
-        user = UserModel.find_by_id(1)
-
+    def test_request_with_invalid_user(self, send_reset_email):
         response = self.client.post('/api/forgot_password', json={'email': 'invalid_email@nickschimek.com'})
 
-        stubbed_reset_password_method.assert_not_called()
+        send_reset_email.assert_not_called()
         assert is_valid(response, 400)

--- a/tests/integration/test_forgot_password.py
+++ b/tests/integration/test_forgot_password.py
@@ -25,10 +25,19 @@ class TestForgotPassword:
         assert response.json == user.json()
 
     @patch.object(Email, 'send_reset_password_msg')
-    def test_password_reset_email_sent(self, stubbed_reset_password_method):
+    def test_reset_password_email_sent(self, stubbed_reset_password_method):
         user = UserModel.find_by_id(1)
 
         response = self.client.post('/api/forgot_password', json={'email': user.email})
 
         stubbed_reset_password_method.assert_called_once_with(user)
         assert is_valid(response, 200)
+
+    @patch.object(Email, 'send_reset_password_msg')
+    def test_reset_password_email_is_not_sent_when_invalid_user(self, stubbed_reset_password_method):
+        user = UserModel.find_by_id(1)
+
+        response = self.client.post('/api/forgot_password', json={'email': 'invalid_email@nickschimek.com'})
+
+        stubbed_reset_password_method.assert_not_called()
+        assert is_valid(response, 400)

--- a/tests/integration/test_forgot_password.py
+++ b/tests/integration/test_forgot_password.py
@@ -1,6 +1,9 @@
 import pytest
 from models.user import UserModel
 from conftest import is_valid
+from unittest.mock import patch
+from resources.email import Email
+
 
 @pytest.mark.usefixtures('client_class', 'test_database')
 class TestForgotPassword:
@@ -20,4 +23,12 @@ class TestForgotPassword:
 
         assert is_valid(response, 200)
         assert response.json == user.json()
-         
+
+    @patch.object(Email, 'send_reset_password_msg')
+    def test_password_reset_email_sent(self, stubbed_reset_password_method):
+        user = UserModel.find_by_id(1)
+
+        response = self.client.post('/api/forgot_password', json={'email': user.email})
+
+        stubbed_reset_password_method.assert_called_once_with(user)
+        assert is_valid(response, 200)

--- a/tests/integration/test_forgot_password.py
+++ b/tests/integration/test_forgot_password.py
@@ -1,0 +1,23 @@
+import pytest
+from models.user import UserModel
+from conftest import is_valid
+
+@pytest.mark.usefixtures('client_class', 'test_database')
+class TestForgotPassword:
+    def test_request_with_invalid_params(self):
+        response = self.client.post('/api/forgot_password')
+        assert is_valid(response, 400)
+        assert response.json == {'message': {'email': 'This field cannot be blank.'}}
+
+    def test_response_with_invalid_email(self):
+        response = self.client.post('/api/forgot_password', json={'email': 'invalid@example.org'})
+        assert is_valid(response, 400)
+        assert response.json == {'message': 'Unable to find email'}
+
+    def test_response_with_valid_email(self):
+        user = UserModel.find_by_id(1)
+        response = self.client.post('/api/forgot_password', json={'email': user.email})
+
+        assert is_valid(response, 200)
+        assert response.json == user.json()
+         

--- a/tests/integration/test_mailers.py
+++ b/tests/integration/test_mailers.py
@@ -1,7 +1,8 @@
 import pytest
 from conftest import is_valid
 from unittest.mock import patch
-from flask_mail import Mail
+from flask_mail import Mail, Message
+from resources.email import Email
 
 
 @pytest.mark.usefixtures('client_class', 'test_database')
@@ -94,3 +95,11 @@ class TestEmailAuthorizations:
                 response = self.client.post(self.endpoint, json=payload, headers=token)
                 assert is_valid(response, 401)
                 assert response.json == {'message': "Admin Access Required"}
+
+
+@pytest.mark.usefixtures('test_database')
+class TesttEmail:
+    @patch.object(Mail, 'send')
+    def test_reset_password_msg(self, send_mail_msg, new_user):
+        Email.send_reset_password_msg(new_user)
+        send_mail_msg.assert_called()

--- a/tests/integration/test_mailers.py
+++ b/tests/integration/test_mailers.py
@@ -12,8 +12,8 @@ class TestPostEmail:
     @patch.object(Mail, 'send')
     def test_email_can_be_sent(self, send_mail_msg, auth_headers):
         payload = {
-                'userid': 1,
-                'title': 'Some email subject',
+                'user_id': 1,
+                'subject': 'Some email subject',
                 'body': 'Some body'
             }
         
@@ -29,7 +29,7 @@ class TestPostEmail:
     @patch.object(Mail, 'send')
     def test_user_id_param_is_required(self, send_mail_msg, auth_headers):
         payload = {
-                'title': 'Some email subject',
+                'subject': 'Some email subject',
                 'body': 'Some body'
             }
         response = self.client.post(
@@ -44,7 +44,7 @@ class TestPostEmail:
     @patch.object(Mail, 'send')
     def test_subject_param_is_required(self, send_mail_msg, auth_headers):
         payload = {
-                'userid': 1,
+                'user_id': 1,
                 'body': 'Some body'
             }
         response = self.client.post(
@@ -59,8 +59,8 @@ class TestPostEmail:
     @patch.object(Mail, 'send')
     def test_body_param_is_required(self, send_mail_msg, auth_headers):
         payload = {
-                'userid': 1,
-                'title': 'Some email subject',
+                'user_id': 1,
+                'subject': 'Some email subject',
             }
         response = self.client.post(
                 self.endpoint,
@@ -85,8 +85,8 @@ class TestEmailAuthorizations:
 
     def test_all_roles_except_admin_are_denied_access(self, auth_headers):
         payload = {
-                'userid': 1,
-                'title': 'Some email subject',
+                'user_id': 1,
+                'subject': 'Some email subject',
                 'body': 'Some body'
             }
         for role, token in auth_headers.items():

--- a/tests/integration/test_mailers.py
+++ b/tests/integration/test_mailers.py
@@ -38,7 +38,7 @@ class TestPostEmail:
                 headers=auth_headers["admin"]
             )
 
-        assert response.json == {'Message': 'Bad Request'}, 400
+        assert response.status == '400 BAD REQUEST'
         send_mail_msg.assert_not_called()
 
     @patch.object(Mail, 'send')
@@ -53,7 +53,7 @@ class TestPostEmail:
                 headers=auth_headers["admin"]
             )
 
-        assert response.json == {'Message': 'Bad Request'}, 400
+        assert response.status == '400 BAD REQUEST'
         send_mail_msg.assert_not_called()
 
     @patch.object(Mail, 'send')
@@ -68,7 +68,7 @@ class TestPostEmail:
                 headers=auth_headers["admin"]
             )
 
-        assert response.json == {'Message': 'Bad Request'}, 400
+        assert response.status == '400 BAD REQUEST'
         send_mail_msg.assert_not_called()
 
 

--- a/tests/integration/test_mailers.py
+++ b/tests/integration/test_mailers.py
@@ -1,0 +1,26 @@
+import pytest
+from conftest import is_valid
+from unittest.mock import patch
+from flask_mail import Mail
+
+
+@pytest.mark.usefixtures('client_class', 'test_database')
+class TestPostEmail:
+    def setup(self):
+        self.endpoint = '/api/user/message'
+
+    @patch.object(Mail, 'send')
+    def test_email_can_be_sent(self, stubbed_send, auth_headers):
+        payload = {
+                'userid': 1,
+                'title': 'Some email subject',
+                'body': 'Some body'
+            }
+        
+        response = self.client.post(
+                f'{self.endpoint}',
+                json=payload,
+                headers=auth_headers["admin"]
+            )
+        assert is_valid(response, 200)
+        stubbed_send.assert_called()

--- a/tests/integration/test_reset_password.py
+++ b/tests/integration/test_reset_password.py
@@ -8,20 +8,22 @@ from tests.time import Time
 
 
 @pytest.mark.usefixtures('client_class', 'test_database')
-class TestForgotPasswordPOST:
+class TestResetPasswordPOST:
+    def setup(self):
+        self.endpoint = '/api/reset-password'
     def test_request_with_invalid_params(self):
-        response = self.client.post('/api/forgot_password')
+        response = self.client.post(self.endpoint)
         assert is_valid(response, 400)
 
     def test_request_with_invalid_email(self):
-        response = self.client.post('/api/forgot_password', json={'email': 'invalid@example.org'})
+        response = self.client.post(self.endpoint, json={'email': 'invalid@example.org'})
         assert is_valid(response, 400)
         assert response.json == {'message': 'Invalid email'}
 
     @patch.object(Email, 'send_reset_password_msg')
     def test_request_with_valid_email(self, send_reset_email):
         user = UserModel.find_by_id(1)
-        response = self.client.post('/api/forgot_password', json={'email': user.email})
+        response = self.client.post(self.endpoint, json={'email': user.email})
 
         assert is_valid(response, 200)
         assert response.json == {"message": "Email sent"}
@@ -30,16 +32,18 @@ class TestForgotPasswordPOST:
 
     @patch.object(Email, 'send_reset_password_msg')
     def test_request_with_invalid_user(self, send_reset_email):
-        response = self.client.post('/api/forgot_password', json={'email': 'invalid_email@nickschimek.com'})
+        response = self.client.post(self.endpoint, json={'email': 'invalid_email@nickschimek.com'})
 
         send_reset_email.assert_not_called()
         assert is_valid(response, 400)
 
 
 @pytest.mark.usefixtures('client_class', 'test_database')
-class TestForgotPasswordGET:
+class TestResetPasswordGET:
+    def setup(self):
+        self.endpoint = '/api/reset-password'
     def test_request_with_invalid_params(self):
-        response = self.client.get('/api/forgot_password/garbage_request')
+        response = self.client.get(f'{self.endpoint}/garbage_request')
         assert response.status == '422 UNPROCESSABLE ENTITY'
         assert response.json == {'msg': 'Not enough segments'}
 
@@ -47,7 +51,7 @@ class TestForgotPasswordGET:
         with freeze_time(Time.yesterday()):
             token = new_user.reset_password_token()
 
-        response = self.client.get(f'/api/forgot_password/{token}')
+        response = self.client.get(f'{self.endpoint}/{token}')
 
         assert response.status == '422 UNPROCESSABLE ENTITY'
         assert response.json == {'message': 'Expired token'}
@@ -55,7 +59,7 @@ class TestForgotPasswordGET:
     def test_request_with_valid_token(self, new_user):
         token = new_user.reset_password_token()
 
-        response = self.client.get(f'/api/forgot_password/{token}')
+        response = self.client.get(f'{self.endpoint}/{token}')
 
         assert response.status == '200 OK'
         assert response.json == {

--- a/tests/time.py
+++ b/tests/time.py
@@ -15,3 +15,6 @@ class Time:
     def one_year_from_now():
         return Time.format_date(datetime.today() + relativedelta(years=1))
 
+    @staticmethod
+    def yesterday():
+      return Time.format_date(datetime.today() - relativedelta(days=1))

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -21,7 +21,7 @@ def test_reset_password_token(stubbed_encode, app, test_database):
 
     with freeze_time(time.ctime(time.time())):
         ten_minutes = time.time() + 600
-        payload = {'reset_password': user.id, 'exp': ten_minutes}
+        payload = {'user_id': user.id, 'exp': ten_minutes}
 
         assert user.reset_password_token()
         stubbed_encode.assert_called_once_with(payload, app.secret_key, algorithm='HS256')

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -1,4 +1,8 @@
 from models.user import UserModel, RoleEnum
+from unittest.mock import patch
+import jwt
+import time
+from freezegun import freeze_time
 
 adminUserEmail = "user1@dwellingly.org"
 adminRole = RoleEnum.ADMIN
@@ -11,3 +15,13 @@ def test_admin_user():
     assert admin_user.role == adminRole
     assert admin_user.phone == phone
 
+@patch.object(jwt, 'encode')
+def test_reset_password_token(stubbed_encode, app, test_database):
+    user = UserModel.find_by_id(1)
+
+    with freeze_time(time.ctime(time.time())):
+        ten_minutes = time.time() + 600
+        payload = {'reset_password': user.id, 'exp': ten_minutes}
+
+        assert user.reset_password_token()
+        stubbed_encode.assert_called_once_with(payload, app.secret_key, algorithm='HS256')


### PR DESCRIPTION
### What issue is this solving?
Resolves #codeforpdx/dwellingly-app/issues/277 and Resolves #codeforpdx/dwellingly-app/issues/289

Created two new endpoints. One endpoint fires off an email to the user. The 2nd endpoint verifies the link the user uses in the email. The email sends a short lived (10 minute) jwt containing the user_id to the address on file to verify a user's identity.

Fixed email setup/configs and created tests for the email class.

Other stuff I did are all in the commits, might be best to review commit by commit as I tried to keep each change in the commit small, and wrote an explanation in the commit message when I felt compelled.

Note to self: one json result returns 'msg' when all the others return 'message'. Will probably have to change all of them to 'msg' to match the libraries implementation. It would be good to match the format across the app. We can probably customize the library to return what we want.

Here are some images:


<img width="1185" alt="Screen Shot 2020-09-12 at 10 11 06 PM" src="https://user-images.githubusercontent.com/19519317/92996946-70f96900-f54a-11ea-8fe6-d86292659012.png">


<img width="332" alt="Screen Shot 2020-09-12 at 10 31 34 PM" src="https://user-images.githubusercontent.com/19519317/92997003-c7ff3e00-f54a-11ea-9e8a-cb852f9a75cc.png">


<img width="237" alt="Screen Shot 2020-09-12 at 10 13 06 PM" src="https://user-images.githubusercontent.com/19519317/92996958-88d0ed00-f54a-11ea-8928-ae0d9bdf59b0.png">


### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? No
Any new dependencies to install? No
Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
