### PR TITLE
Fix instructions in README for seeding db

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ NOTE: Database is SQLite3 via SQLAlchemy
 4. Run `pipenv install -d`
    - If you get the error `ImportError: cannot import name 'Feature' from 'setuptools'`, your setuptools version might be at 46 or later. You may be able to get it to work using version 45 (e.g. `pip3 install setuptools==45`)
 5. Seed the database
-   - Run: `pipenv run python seed_db.py`
+   - Run: `pipenv run python manage.py create`
    - To re-seed the database from scratch, delete data.db before running the script
    - Look for the file data.db to be created in the root directory
    - If you get the error `ImportError: No module named flask` or similar, you may need to run `pipenv shell` to launch virtual environment.


### PR DESCRIPTION
The instructions for seeding the db on macosx seemed out of date;
they suggested running `seed_db.py`, which doesn't exist.  When
the flask app fails due to missing db, it instead suggests running
`manage.py create`.  That command worked in my environment and allowed
me to get the flask app up and running without an invalid database error,
so this commit updates the README to recommend that command instead.