### PR TITLE
Add keyword example to automatically close issues

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,6 @@
 ### What issue is this solving?
-Please post a link to the issue (on the front end repo) that this PR is resolving.
+<!-- replace ### with the issue number. This will ensure the issue is automatically closed when the PR is merged. -->
+Closes https://github.com/codeforpdx/dwellingly-app/issues/###
 
 ### Any helpful knowledge/context for the reviewer?
 Is a re-seeding of the database necessary?

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 ### What issue is this solving?
-<!-- replace ### with the issue number. This will ensure the issue is automatically closed when the PR is merged. -->
-Closes https://github.com/codeforpdx/dwellingly-app/issues/###
+<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
+Closes codeforpdx/dwellingly-app/issues/###
 
 ### Any helpful knowledge/context for the reviewer?
 Is a re-seeding of the database necessary?


### PR DESCRIPTION
### What issue is this solving?
When PR's are merged the issues are not being automatically closed. Added an example of how to link a PR to automatically close an issue on the dwellingly-app repo.

source: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords