### PR TITLE
Use python 3.8 to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,7 @@
 language: python
-
 python:
-  - "3.6"
-  - "3.7"
   - "3.8"
-  - "nightly"
-
-matrix:
-  allow_failures:
-    - python: "nightly"
-
 install:
   - pip install pipenv --upgrade-strategy=only-if-needed
   - pipenv install --dev
-
 script: pytest


### PR DESCRIPTION
Removed python 3.6, 3.7, and nightly python build.

Running tests under other versions of python is not necessary for our
application, and doing so only increases CI time and could trigger
unnecessary CI failures.

This change reduced the CI time from `Total time 7 min 9 sec` down to `1 min 28 sec`