### PR TITLE
Add get user by role endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from models.property import PropertyModel
 from models.tenant import TenantModel
 from models.tenant_staff_link import StaffTenantLink
 from models.revoked_tokens import RevokedTokensModel
-from resources.user import UserRegister, User, UserLogin, ArchiveUser, UsersRole, UserAccessRefresh, UserRoles
+from resources.user import UserRegister, User, UserLogin, ArchiveUser, UsersRole, UserAccessRefresh, UserRoles, Users
 from resources.reset_password import ResetPassword
 from resources.property import Properties, Property, ArchiveProperty
 from resources.tenants import Tenants
@@ -60,8 +60,8 @@ def create_routes(app):
     api.add_resource(Property,'properties/<string:name>') #TODO change to ID
     api.add_resource(Properties,'properties')
     api.add_resource(ArchiveProperty,'properties/archive/<int:id>')
-    api.add_resource(User, 'user')
     api.add_resource(User, 'user/<int:user_id>')
+    api.add_resource(Users, 'user')
     api.add_resource(UsersRole, 'users/role')
     api.add_resource(ArchiveUser, 'user/archive/<int:user_id>')
     api.add_resource(UserLogin, 'login')

--- a/app.py
+++ b/app.py
@@ -60,6 +60,7 @@ def create_routes(app):
     api.add_resource(Property,'properties/<string:name>') #TODO change to ID
     api.add_resource(Properties,'properties')
     api.add_resource(ArchiveProperty,'properties/archive/<int:id>')
+    api.add_resource(User, 'user')
     api.add_resource(User, 'user/<int:user_id>')
     api.add_resource(UsersRole, 'users/role')
     api.add_resource(ArchiveUser, 'user/archive/<int:user_id>')

--- a/resources/user.py
+++ b/resources/user.py
@@ -43,6 +43,11 @@ class UserRegister(Resource):
         return {"message": "User created successfully."}, 201
 
 class User(Resource):
+
+    @admin_required
+    def get(self):
+        return {}, 200
+
     @admin_required
     def get(self, user_id):
         user = UserModel.find_by_id(user_id)

--- a/resources/user.py
+++ b/resources/user.py
@@ -43,11 +43,6 @@ class UserRegister(Resource):
         return {"message": "User created successfully."}, 201
 
 class User(Resource):
-
-    @admin_required
-    def get(self):
-        return {}, 200
-
     @admin_required
     def get(self, user_id):
         user = UserModel.find_by_id(user_id)
@@ -209,3 +204,8 @@ class UserAccessRefresh(Resource):
             'access_token': create_access_token(identity=current_user)
         }
         return ret, 200
+
+class Users(Resource):
+    @admin_required
+    def get(self):
+        return {}, 200

--- a/resources/user.py
+++ b/resources/user.py
@@ -1,4 +1,5 @@
 from flask_restful import Resource, reqparse
+from flask import request
 
 from models.property import PropertyModel
 from models.tenant import TenantModel
@@ -208,4 +209,12 @@ class UserAccessRefresh(Resource):
 class Users(Resource):
     @admin_required
     def get(self):
-        return {}, 200
+
+        role = RoleEnum(int(request.args["r"]))
+        users = UserModel.find_by_role(role)
+        ret = [user.json() for user in users]
+
+        print("----------")
+        print(ret)
+
+        return {"message": ret}, 200

--- a/resources/user.py
+++ b/resources/user.py
@@ -214,7 +214,4 @@ class Users(Resource):
         users = UserModel.find_by_role(role)
         ret = [user.json() for user in users]
 
-        print("----------")
-        print(ret)
-
         return {"message": ret}, 200

--- a/resources/user.py
+++ b/resources/user.py
@@ -210,9 +210,13 @@ class Users(Resource):
     @admin_required
     def get(self):
 
-        role = RoleEnum(int(request.args["r"]))
+        role_query = int(request.args["r"])
+
+        if role_query not in range(0, 5):
+            return {"message": "Invalid role"}, 400
+
+        role = RoleEnum(role_query)
         users = [user.json() for user in UserModel.find_by_role(role)]
-        print(users)
         ret = [{
             "id": user["id"],
             "firstName": user["firstName"],

--- a/resources/user.py
+++ b/resources/user.py
@@ -212,15 +212,16 @@ class Users(Resource):
 
         role = RoleEnum(int(request.args["r"]))
         users = [user.json() for user in UserModel.find_by_role(role)]
+        print(users)
         ret = [{
-            id: user.id,
-            firstName: user.firstName,
-            lastName: user.lastName,
-            email: user.email,
-            phone: user.phone,
-            role: user.phone,
-            tickets: "TODO",
-            tenants: "TODO"
+            "id": user["id"],
+            "firstName": user["firstName"],
+            "lastName": user["lastName"],
+            "email": user["email"],
+            "phone": user["phone"],
+            "role": user["role"],
+            "tickets": "TODO",
+            "tenants": "TODO"
             } for user in users]
 
-        return {f"{role}": ret}, 200
+        return {"users": ret}, 200

--- a/resources/user.py
+++ b/resources/user.py
@@ -211,7 +211,16 @@ class Users(Resource):
     def get(self):
 
         role = RoleEnum(int(request.args["r"]))
-        users = UserModel.find_by_role(role)
-        ret = [user.json() for user in users]
+        users = [user.json() for user in UserModel.find_by_role(role)]
+        ret = [{
+            id: user.id,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            email: user.email,
+            phone: user.phone,
+            role: user.phone,
+            tickets: "TODO",
+            tenants: "TODO"
+            } for user in users]
 
-        return {"message": ret}, 200
+        return {f"{role}": ret}, 200

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -203,14 +203,14 @@ def test_delete_user(client, auth_headers, new_user):
 def test_get_user(client, auth_headers, new_user):
     """GET '/user' returns a list of all users queried by role"""
 
-    tenant_user_response = client.get('/api/user?r=1', headers=auth_headers["admin"])
     staff_user_response = client.get('/api/user?r=3', headers=auth_headers["admin"])
+    tenant_user_response = client.get('/api/user?r=4', headers=auth_headers["admin"])
 
-    assert is_valid(tenant_user_response, 200)
     assert is_valid(staff_user_response, 200)
+    assert is_valid(admin_user_response, 200)
     print(tenant_user_response)
-    assert all(tenant.role == "tenant" for tenant in tenant_user_response.json["tenants"])
-    assert all(staff.role == "staff" for staff in staff_user_response.json["staff"])
+    assert all(staff.role == "STAFF" for staff in staff_user_response.json["staff"])
+    assert all(admin.role == "ADMIN" for admin in admin_user_response.json["admin"])
 
     """Queries with a non-existing role returns a 400 response"""
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -208,8 +208,8 @@ def test_get_user(client, auth_headers, new_user):
 
     assert is_valid(staff_user_response, 200)
     assert is_valid(admin_user_response, 200)
-    assert all(staff["role"] == 3 for staff in staff_user_response.json["users"])
-    assert all(admin["role"] == 4 for admin in admin_user_response.json["users"])
+    assert all(staff["role"] == RoleEnum.STAFF.value for staff in staff_user_response.json["users"])
+    assert all(admin["role"] == RoleEnum.ADMIN.value for admin in admin_user_response.json["users"])
 
     """Queries with a non-existing role returns a 400 response"""
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -218,5 +218,5 @@ def test_get_user(client, auth_headers, new_user):
 
     """Non-admin requests return a 401 status code"""
 
-    unauthorized_user_reponse = client.get('api/user?r=3', headers=auth_headers["staff"])
-    assert is_valid(unauthorized_user_resopnse, 401)
+    unauthorized_user_response = client.get('api/user?r=3', headers=auth_headers["pm"])
+    assert is_valid(unauthorized_user_response, 401)

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -209,10 +209,15 @@ def test_get_user(client, auth_headers, new_user):
     staff_user_response = client.get('/api/user?r=3', headers=auth_headers["admin"])
     admin_user_response = client.get('/api/user?r=4', headers=auth_headers["admin"])
 
-    """Queries with a non-existing role returns a 404 response"""
+    assert is_valid(pending_user_response, 200)
+    assert all(staff.role == "staff" for staff in staff_user_response.json["staff"])
+
+    """Queries with a non-existing role returns a 400 response"""
 
     unknown_user_response = client.get('api/user?r=5', headers=auth_headers["admin"])
+    assert is_valid(unknown_user_response, 400)
 
-    """Non-admins cannot view a list of users"""
+    """Non-admin requests return a 401 status code"""
 
     unauthorized_user_reponse = client.get('api/user?r=3', headers=auth_headers["staff"])
+    assert is_valid(unauthorized_user_resopnse, 401)

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -204,12 +204,12 @@ def test_get_user(client, auth_headers, new_user):
     """GET '/user' returns a list of all users queried by role"""
 
     staff_user_response = client.get('/api/user?r=3', headers=auth_headers["admin"])
-    tenant_user_response = client.get('/api/user?r=4', headers=auth_headers["admin"])
+    admin_user_response = client.get('/api/user?r=4', headers=auth_headers["admin"])
 
     assert is_valid(staff_user_response, 200)
     assert is_valid(admin_user_response, 200)
-    assert all(staff.role == "3" for staff in staff_user_response.json["staff"])
-    assert all(admin.role == "4" for admin in admin_user_response.json["admin"])
+    assert all(staff["role"] == 3 for staff in staff_user_response.json["users"])
+    assert all(admin["role"] == 4 for admin in admin_user_response.json["users"])
 
     """Queries with a non-existing role returns a 400 response"""
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -203,13 +203,12 @@ def test_delete_user(client, auth_headers, new_user):
 def test_get_user(client, auth_headers, new_user):
     """GET '/user' returns a list of all users queried by role"""
 
-    pending_user_response = client.get('/api/user?r=0', headers=auth_headers["admin"])
     tenant_user_response = client.get('/api/user?r=1', headers=auth_headers["admin"])
-    property_manager_user_response = client.get('/api/user?r=2', headers=auth_headers["admin"])
     staff_user_response = client.get('/api/user?r=3', headers=auth_headers["admin"])
-    admin_user_response = client.get('/api/user?r=4', headers=auth_headers["admin"])
 
-    assert is_valid(pending_user_response, 200)
+    assert is_valid(tenant_user_response, 200)
+    assert is_valid(staff_user_response, 200)
+    assert all(tenant.role == "tenant" for tenant in tenant_user_response.json["tenants"])
     assert all(staff.role == "staff" for staff in staff_user_response.json["staff"])
 
     """Queries with a non-existing role returns a 400 response"""

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -208,9 +208,8 @@ def test_get_user(client, auth_headers, new_user):
 
     assert is_valid(staff_user_response, 200)
     assert is_valid(admin_user_response, 200)
-    print(tenant_user_response)
-    assert all(staff.role == "STAFF" for staff in staff_user_response.json["staff"])
-    assert all(admin.role == "ADMIN" for admin in admin_user_response.json["admin"])
+    assert all(staff.role == "3" for staff in staff_user_response.json["staff"])
+    assert all(admin.role == "4" for admin in admin_user_response.json["admin"])
 
     """Queries with a non-existing role returns a 400 response"""
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -198,3 +198,21 @@ def test_delete_user(client, auth_headers, new_user):
 
     response = client.delete("/api/user/999999", headers=auth_headers["admin"])
     assert is_valid(response, 400) # BAD REQUEST
+
+
+def test_get_user(client, auth_headers, new_user):
+    """GET '/user' returns a list of all users queried by role"""
+
+    pending_user_response = client.get('/api/user?r=0', headers=auth_headers["admin"])
+    tenant_user_response = client.get('/api/user?r=1', headers=auth_headers["admin"])
+    property_manager_user_response = client.get('/api/user?r=2', headers=auth_headers["admin"])
+    staff_user_response = client.get('/api/user?r=3', headers=auth_headers["admin"])
+    admin_user_response = client.get('/api/user?r=4', headers=auth_headers["admin"])
+
+    """Queries with a non-existing role returns a 404 response"""
+
+    unknown_user_response = client.get('api/user?r=5', headers=auth_headers["admin"])
+
+    """Non-admins cannot view a list of users"""
+
+    unauthorized_user_reponse = client.get('api/user?r=3', headers=auth_headers["staff"])

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -208,6 +208,7 @@ def test_get_user(client, auth_headers, new_user):
 
     assert is_valid(tenant_user_response, 200)
     assert is_valid(staff_user_response, 200)
+    print(tenant_user_response)
     assert all(tenant.role == "tenant" for tenant in tenant_user_response.json["tenants"])
     assert all(staff.role == "staff" for staff in staff_user_response.json["staff"])
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -203,8 +203,8 @@ def test_delete_user(client, auth_headers, new_user):
 def test_get_user(client, auth_headers, new_user):
     """GET '/user' returns a list of all users queried by role"""
 
-    staff_user_response = client.get('/api/user?r=3', headers=auth_headers["admin"])
-    admin_user_response = client.get('/api/user?r=4', headers=auth_headers["admin"])
+    staff_user_response = client.get(f'/api/user?r={RoleEnum.STAFF.value}', headers=auth_headers["admin"])
+    admin_user_response = client.get(f'/api/user?r={RoleEnum.ADMIN.value}', headers=auth_headers["admin"])
 
     assert is_valid(staff_user_response, 200)
     assert is_valid(admin_user_response, 200)

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -203,12 +203,9 @@ def test_delete_user(client, auth_headers, new_user):
 def test_get_user(client, auth_headers, new_user):
     """GET '/user' returns a list of all users queried by role"""
 
-    staff_user_response = client.get(f'/api/user?r={RoleEnum.STAFF.value}', headers=auth_headers["admin"])
     admin_user_response = client.get(f'/api/user?r={RoleEnum.ADMIN.value}', headers=auth_headers["admin"])
 
-    assert is_valid(staff_user_response, 200)
     assert is_valid(admin_user_response, 200)
-    assert all(staff["role"] == RoleEnum.STAFF.value for staff in staff_user_response.json["users"])
     assert all(admin["role"] == RoleEnum.ADMIN.value for admin in admin_user_response.json["users"])
 
     """Queries with a non-existing role returns a 400 response"""
@@ -218,5 +215,5 @@ def test_get_user(client, auth_headers, new_user):
 
     """Non-admin requests return a 401 status code"""
 
-    unauthorized_user_response = client.get('api/user?r=3', headers=auth_headers["pm"])
+    unauthorized_user_response = client.get(f'api/user?r={RoleEnum.PROPERTY_MANAGER.value}', headers=auth_headers["pm"])
     assert is_valid(unauthorized_user_response, 401)


### PR DESCRIPTION
### What issue is this solving?

codeforpdx/dwellingly-app/issues/296 (should not close - frontend work required)

Supplies backend api endpoint to display user data based on queried role (formatted '/user?r=<int>'). Endpoint is locked behind admin permissions. This will allow us to populate the JOIN staff page on the front end.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary?
Any new dependencies to install?
Any special requirements to test?

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
