### PR TITLE
Audited lease return messages

### DIFF
--- a/resources/lease.py
+++ b/resources/lease.py
@@ -21,27 +21,26 @@ class Lease(Resource):
         if lease:
             return lease.json()
 
-        return {'Message': 'Lease Not Found'}, 404
+        return {'message': 'Lease Not Found'}, 404
    
     @jwt_required
     def put(self,id):
         data = Lease.parser.parse_args()
         update = False
 
-        if not LeaseModel.find_by_id(id):
-            return {'Message': 'Lease Not Found'}, 404  
-            
         baseLease = LeaseModel.find_by_id(id)
-       
+        if not baseLease:
+            return {'message': 'Lease Not Found'}, 404
+
 
         if(data.occupants):
             baseLease.occupants = data.occupants
             update = True
-        
+
         if(data.name):
             baseLease.name = data.name
             update = True
-        
+
         if(data.landlordID):
             baseLease.landlordID = data.landlordID
             update = True
@@ -49,7 +48,7 @@ class Lease(Resource):
         if(data.propertyID):
             baseLease.propertyID = data.propertyID
             update = True
-    
+
         if(data.tenantID):
             baseLease.tenantID = data.tenantID
             update = True
@@ -64,34 +63,34 @@ class Lease(Resource):
 
         if update == False:
             return baseLease.json(), 400
-        else: 
-            baseLease.dateUpdated = datetime.now()                         
+        else:
+            baseLease.dateUpdated = datetime.now()
 
         try:
             baseLease.save_to_db()
         except:
-            return {'Message': 'An Error Has Occured'}, 500
+            return {'message': 'An Error Has Occured'}, 500
 
         return baseLease.json(), 200
-    
+
     @jwt_required
     def delete(self, id):
         lease = LeaseModel.find_by_id(id)
         if lease:
             lease.delete_from_db()
-            return{'Message': 'Lease Removed from Database'}, 200
-        else: 
-            return{'Message': 'Lease Not Found'}, 404
+            return{'message': 'Lease Removed from Database'}, 200
+        else:
+            return{'message': 'Lease Not Found'}, 404
 
 class Leases(Resource):
-    @jwt_required    
+    @jwt_required
     def get(self):
         return {'Leases': [lease.json() for lease in LeaseModel.query.all()]}
-    
+
     @jwt_required
     def post(self):
         data = Lease.parser.parse_args()
-        
+
         #convert strings to DateTime Object
         data.dateTimeStart = datetime.strptime(data.dateTimeStart, '%m/%d/%Y %H:%M:%S')
         data.dateTimeEnd = datetime.strptime(data.dateTimeEnd, '%m/%d/%Y %H:%M:%S')
@@ -102,6 +101,7 @@ class Leases(Resource):
         try:
             lease.save_to_db()
         except:
-            return {'Message': 'An Error Has Occured'}, 500
+            return {'message': 'An Error Has Occured'}, 500
 
-        return 201, 201
+        return {'message': 'Lease Created Successfully'}, 201
+

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -33,7 +33,7 @@ class TestGetLease:
             )
 
         assert is_valid(response, 404)
-        assert response.json == {'Message': 'Lease Not Found'}
+        assert response.json == {'message': 'Lease Not Found'}
 
     def test_unauthorized_request_for_a_lease(self):
         response = self.client.get(f'{self.endpoint}/{self.lease.id}')
@@ -85,8 +85,9 @@ class TestCreateLease:
         num_leases = len(LeaseModel.query.all())
         response = self.client.post(self.endpoint, json=self.valid_payload, headers=auth_headers["pm"])
 
+
         assert is_valid(response, 201)
-        assert response.json == 201
+        assert response.json == {'message': 'Lease Created Successfully'}
         assert num_leases + 1 == len(LeaseModel.query.all())
 
     def test_unauthorized_request_with_valid_payload(self):
@@ -111,7 +112,7 @@ class TestDeleteLease:
         response = self.client.delete(f'{self.endpoint}/1', headers=auth_headers["pm"])
 
         assert is_valid(response, 200)
-        assert response.json == {'Message': 'Lease Removed from Database'}
+        assert response.json == {'message': 'Lease Removed from Database'}
         assert num_leases - 1 == len(LeaseModel.query.all())
 
     def test_authorized_request_with_invalid_lease_id(self, auth_headers):
@@ -119,7 +120,7 @@ class TestDeleteLease:
         response = self.client.delete(f'{self.endpoint}/504', headers=auth_headers["pm"])
 
         assert is_valid(response, 404) 
-        assert response.json == {'Message': 'Lease Not Found'}
+        assert response.json == {'message': 'Lease Not Found'}
         assert num_leases == len(LeaseModel.query.all())
 
 
@@ -133,7 +134,7 @@ class TestUpdateLease:
         response = self.client.put(f'{self.endpoint}/504', headers=auth_headers["pm"])
 
         assert is_valid(response, 404)
-        assert response.json == {'Message': 'Lease Not Found'}
+        assert response.json == {'message': 'Lease Not Found'}
 
     def test_date_is_updated_with_valid_payload(self, auth_headers):
         payload = {'dateTimeEnd': Time.one_year_from_now()}


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes [codeforpdx/dwellingly-app/issues/337](https://github.com/codeforpdx/dwellingly-app/issues/337)

* Added {'message': 'Lease Created Successfully'} return message for the create lease end point. 
* Changed {'Message': ....} to {'message': ....}
* Left {'msg': ...} along. This will need to be changed in the pyjwt configuration. 
### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? No
Any new dependencies to install? No
Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards
- [ x] Code builds successfully
- [ x] Code has been tested and does not produce errors
- [ x] Code is readable and formatted
- [ x] There isn't any unnecessary commented-out code
