### PR TITLE
Fix typo in email templates: Dwellinlgy -> Dwellingly

### DIFF
--- a/templates/emails/reset_msg.html
+++ b/templates/emails/reset_msg.html
@@ -10,4 +10,4 @@
 
 
 <p>Best,</p>
-<p>Team Dwellinlgy.</p>
+<p>Team Dwellingly.</p>

--- a/templates/emails/reset_msg.txt
+++ b/templates/emails/reset_msg.txt
@@ -7,4 +7,4 @@ To reset your password click on the following link:
 If you have not requested a password reset simply ignore this message.
 
 Best,
-Team Dwellinlgy.
+Team Dwellingly.


### PR DESCRIPTION
I left out the MR template info because this is such a small change. 