### PR TITLE
Iss356 move off flask script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,11 @@ NOTE: Database is SQLite3 via SQLAlchemy
    - Note: Pipenv may prompt you to install Python if it cannot find the correct version on your system. You should select Yes.
    - Note: If you get the error `ImportError: cannot import name 'Feature' from 'setuptools'`, your setuptools version might be at 46 or later. You may be able to get it to work using version 45 (e.g. `pip3 install setuptools==45`)
 4. Create and Seed the database
-   - Run: `pipenv run python manage.py create`
-   - To re-seed the database from scratch, delete data.db before running the script
+   - Run: `pipenv run flask db create`
+   - To re-seed the database from scratch run: `pipenv run flask db recreate`
    - Look for the file data.db to be created in the root directory
    - If you get the error `ImportError: No module named flask` or similar, you may need to run `pipenv shell` to launch virtual environment.
+   - To find other database set-up commands run: `pipenv run flask db --help`
 5. Start the server using the flask environment (required every time the project is re-opened):
    - Run: `pipenv run flask run`
    - Run + restart the server on changes: `pipenv run flask run --reload`

--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from resources.lease import Lease, Leases
 from resources.widgets import Widgets
 import os
 from db import db
+from manage import dbsetup
 
 def config_app(app):
     #config DataBase
@@ -133,7 +134,7 @@ def create_app():
 
 
 app = create_app()
-
+app.register_blueprint(dbsetup)
 
 if __name__ == '__main__':
     app.run(port=5000, debug=True)

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,7 @@ import click
 from db import db
 from data.seedData import seedData
 from flask import Blueprint
+import sys
 
 dbsetup = Blueprint('db', __name__)
 """
@@ -31,3 +32,9 @@ def recreate():
         db.drop_all()
         db.create_all()
         seedData()
+
+if __name__ == '__main__':
+    print("'pipenv run python manage.py {}' ".format(sys.argv[1])+
+          "has been deprecated\n" + 
+          "please use 'pipenv run flask db {}'".format(sys.argv[1]))
+

--- a/manage.py
+++ b/manage.py
@@ -1,38 +1,33 @@
-from app import create_app
-from flask_script import Manager, prompt_bool
+import click
 from db import db
 from data.seedData import seedData
+from flask import Blueprint
 
-app = create_app()
-manager = Manager(app)
-
+dbsetup = Blueprint('db', __name__)
 """
     *****Database Commands*****
 """
-
-@manager.command
+@dbsetup.cli.command("populate")
 def populate():
     """Seed the database with default data"""
     seedData()
 
-@manager.command
+@dbsetup.cli.command("create")
 def create():
     """Creates database tables and populates with seed data"""
     db.create_all()
-    populate()
+    seedData()
 
-@manager.command
+@dbsetup.cli.command("drop")
 def drop():
     """Drops all database tables"""
-    if prompt_bool("Are you sure you want to lose all your data"):
+    if click.confirm("Are you sure you want to lose all your data"):
         db.drop_all()
 
-@manager.command
+@dbsetup.cli.command("recreate")
 def recreate():
     """Recreates database table and populates with seed data. Know that this will reset your db to defaults"""
-    drop()
-    create()
-
-
-if __name__ == "__main__":
-    manager.run()
+    if click.confirm("Are you sure you want to lose all your data"):
+        db.drop_all()
+        db.create_all()
+        seedData()


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/356

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? No
Any new dependencies to install? No
Any special requirements to test? Yes

There are no unit tests for the command line functions in the "manage.py" file. Should test the command line functions "pipenv run flask db cmd". The various commands are create, recreate, drop and populate. Populate seeds the database, but create and recreate automatically seed the database. 

Using 'pipenv run python manage.py cmd' prints a message to the console directing the user to use 'pipenv run flask db cmd'. 

CONTRIBUTE.md has been updated to reflect the new instructions.
### Please make sure you've attempted to meet the following coding standards
- [ x] Code builds successfully
- [ x] Code has been tested and does not produce errors
- [ x] Code is readable and formatted
- [ x] There isn't any unnecessary commented-out code
