### PR TITLE
Refactor lease endpoint/tests example

### DIFF
--- a/data/seedData.py
+++ b/data/seedData.py
@@ -222,7 +222,6 @@ def seedData():
                          tenantID=tenant_renty_mcrenter.id,
                          dateTimeStart=now,
                          dateTimeEnd=future,
-                         dateUpdated=now,
                          occupants=3)
     lease_1.save_to_db()
     lease_2 = LeaseModel(name="Lease 2",
@@ -230,7 +229,6 @@ def seedData():
                          tenantID=tenant_soho_muless.id,
                          dateTimeStart=now,
                          dateTimeEnd=future,
-                         dateUpdated=now,
                          occupants=2)
     lease_2.save_to_db()
     lease_3 = LeaseModel(name="Lease 3",
@@ -238,7 +236,6 @@ def seedData():
                          tenantID=tenant_starvin_artist.id,
                          dateTimeStart=now,
                          dateTimeEnd=future,
-                         dateUpdated=now,
                          occupants=1)
     lease_3.save_to_db()
 

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -30,11 +30,8 @@ class BaseModel(db.Model):
         db.session.delete(self)
         db.session.commit()
 
-    def json(self):
-        raise NotImplementedError(f"This {self.__class__} must implement a <json> method")
-
     def __repr__(self):
-        return f'<{type(self).__name__} {self.json()}>'
+        return "<{!r} {!r}>".format(type(self).__name__, self.__dict__)
 
     @classmethod
     def _name(cls):

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -34,6 +34,22 @@ class BaseModel(db.Model):
         db.session.add(cls(**attrs))
         db.session.commit()
 
+    @classmethod
+    def update(cls, schema, id, attributes):
+        obj = cls.find(id)
+        try:
+            attrs = schema.load(attributes, unknown=EXCLUDE, partial=True)
+        except ValidationError as err:
+            abort(400, err.messages)
+
+        for k, v in attrs.items():
+            setattr(obj, k, v)
+
+        db.session.add(obj)
+        db.session.commit()
+
+        return obj
+
     def save_to_db(self):
         db.session.add(self)
         db.session.commit()

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -27,7 +27,7 @@ class BaseModel(db.Model):
     @classmethod
     def create(cls, schema, attributes):
         try:
-            attrs = schema.load(attributes, unknown=EXCLUDE)
+            attrs = schema().load(attributes, unknown=EXCLUDE)
         except ValidationError as err:
             abort(400, err.messages)
 
@@ -38,7 +38,7 @@ class BaseModel(db.Model):
     def update(cls, schema, id, attributes):
         obj = cls.find(id)
         try:
-            attrs = schema.load(attributes, unknown=EXCLUDE, partial=True)
+            attrs = schema().load(attributes, unknown=EXCLUDE, partial=True)
         except ValidationError as err:
             abort(400, err.messages)
 

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1,3 +1,5 @@
+from flask import abort
+from marshmallow import ValidationError, EXCLUDE
 from db import db
 from datetime import datetime
 
@@ -20,6 +22,16 @@ class BaseModel(db.Model):
     def delete(cls, id):
         obj = cls.find(id)
         db.session.delete(obj)
+        db.session.commit()
+
+    @classmethod
+    def create(cls, schema, attributes):
+        try:
+            attrs = schema.load(attributes, unknown=EXCLUDE)
+        except ValidationError as err:
+            abort(400, err.messages)
+
+        db.session.add(cls(**attrs))
         db.session.commit()
 
     def save_to_db(self):

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -25,9 +25,9 @@ class BaseModel(db.Model):
         db.session.commit()
 
     @classmethod
-    def create(cls, schema, attributes):
+    def create(cls, schema, payload):
         try:
-            attrs = schema().load(attributes, unknown=EXCLUDE)
+            attrs = schema().load(payload, unknown=EXCLUDE)
         except ValidationError as err:
             abort(400, err.messages)
 
@@ -38,10 +38,10 @@ class BaseModel(db.Model):
         return obj
 
     @classmethod
-    def update(cls, schema, id, attributes):
+    def update(cls, schema, id, payload):
         obj = cls.find(id)
         try:
-            attrs = schema().load(attributes, unknown=EXCLUDE, partial=True)
+            attrs = schema().load(payload, unknown=EXCLUDE, partial=True)
         except ValidationError as err:
             abort(400, err.messages)
 

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -31,8 +31,11 @@ class BaseModel(db.Model):
         except ValidationError as err:
             abort(400, err.messages)
 
-        db.session.add(cls(**attrs))
+        obj = cls(**attrs)
+        db.session.add(obj)
         db.session.commit()
+
+        return obj
 
     @classmethod
     def update(cls, schema, id, attributes):

--- a/models/lease.py
+++ b/models/lease.py
@@ -1,8 +1,4 @@
-import datetime
 from db import db
-from models.property import PropertyModel
-from models.user import UserModel
-from models.tenant import TenantModel
 from models.base_model import BaseModel
 
 

--- a/models/lease.py
+++ b/models/lease.py
@@ -11,7 +11,7 @@ class LeaseModel(BaseModel):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100))
-    propertyID = db.Column(db.Integer, db.ForeignKey('properties.id'))
+    propertyID = db.Column(db.Integer, db.ForeignKey('properties.id'), nullable=False)
     tenantID = db.Column(db.Integer, db.ForeignKey('tenants.id'), nullable=False)
     occupants = db.Column(db.Integer)
     dateTimeStart = db.Column(db.DateTime, default=datetime.datetime.utcnow)

--- a/models/lease.py
+++ b/models/lease.py
@@ -14,5 +14,5 @@ class LeaseModel(BaseModel):
     propertyID = db.Column(db.Integer, db.ForeignKey('properties.id'), nullable=False)
     tenantID = db.Column(db.Integer, db.ForeignKey('tenants.id'), nullable=False)
     occupants = db.Column(db.Integer)
-    dateTimeStart = db.Column(db.DateTime, default=datetime.datetime.utcnow)
-    dateTimeEnd = db.Column(db.DateTime, default=datetime.datetime.utcnow)
+    dateTimeStart = db.Column(db.DateTime, nullable=False)
+    dateTimeEnd = db.Column(db.DateTime, nullable=False)

--- a/models/lease.py
+++ b/models/lease.py
@@ -18,15 +18,6 @@ class LeaseModel(BaseModel):
     dateTimeEnd = db.Column(db.DateTime, default=datetime.datetime.utcnow)
     dateUpdated = db.Column(db.DateTime, default=datetime.datetime.utcnow)
 
-    def __init__(self, name, tenantID, propertyID, dateTimeStart, dateTimeEnd, dateUpdated, occupants):
-        self.name = name
-        self.propertyID = propertyID
-        self.tenantID = tenantID
-        self.dateTimeStart = dateTimeStart
-        self.dateTimeEnd = dateTimeEnd
-        self.dateUpdated = dateUpdated
-        self.occupants = occupants
-
     def json(self):
         property = PropertyModel.find_by_id(self.propertyID)
 

--- a/models/lease.py
+++ b/models/lease.py
@@ -16,7 +16,6 @@ class LeaseModel(BaseModel):
     occupants = db.Column(db.Integer)
     dateTimeStart = db.Column(db.DateTime, default=datetime.datetime.utcnow)
     dateTimeEnd = db.Column(db.DateTime, default=datetime.datetime.utcnow)
-    dateUpdated = db.Column(db.DateTime, default=datetime.datetime.utcnow)
 
     def json(self):
         property = PropertyModel.find_by_id(self.propertyID)
@@ -28,6 +27,5 @@ class LeaseModel(BaseModel):
           'tenantID': self.tenant.json(),
           'dateTimeStart': self.dateTimeStart.strftime("%m/%d/%Y %H:%M:%S"),
           'dateTimeEnd': self.dateTimeEnd.strftime("%m/%d/%Y %H:%M:%S"),
-          'dateUpdated': self.dateUpdated.strftime("%m/%d/%Y %H:%M:%S"),
           'occupants': self.occupants
         }

--- a/models/lease.py
+++ b/models/lease.py
@@ -16,16 +16,3 @@ class LeaseModel(BaseModel):
     occupants = db.Column(db.Integer)
     dateTimeStart = db.Column(db.DateTime, default=datetime.datetime.utcnow)
     dateTimeEnd = db.Column(db.DateTime, default=datetime.datetime.utcnow)
-
-    def json(self):
-        property = PropertyModel.find_by_id(self.propertyID)
-
-        return {
-          'id': self.id,
-          'name':self.name,
-          'propertyID': property.json(),
-          'tenantID': self.tenant.json(),
-          'dateTimeStart': self.dateTimeStart.strftime("%m/%d/%Y %H:%M:%S"),
-          'dateTimeEnd': self.dateTimeEnd.strftime("%m/%d/%Y %H:%M:%S"),
-          'occupants': self.occupants
-        }

--- a/models/property.py
+++ b/models/property.py
@@ -1,4 +1,3 @@
-from sqlalchemy.orm import relationship
 from db import db
 from models.tenant import TenantModel
 from models.base_model import BaseModel

--- a/models/property.py
+++ b/models/property.py
@@ -20,6 +20,8 @@ class PropertyModel(BaseModel):
     archived = db.Column(db.Boolean)
 
     tenants = db.relationship(TenantModel, backref="property")
+    leases = db.relationship('LeaseModel',
+        backref='property', lazy=True, cascade="all, delete-orphan")
 
     def __init__(self, name, address, unit, city, state, zipcode, propertyManager, dateAdded, archived):
         self.name = name

--- a/resources/lease.py
+++ b/resources/lease.py
@@ -1,71 +1,18 @@
 from flask import request
-from flask_restful import Resource, reqparse
+from flask_restful import Resource
 from models.lease import LeaseModel
 from schemas.lease import LeaseSchema
-from models.property import PropertyModel
-from datetime import datetime
 from flask_jwt_extended import jwt_required
 
 
 class Lease(Resource):
-    parser = reqparse.RequestParser()
-    parser.add_argument('name')
-    parser.add_argument('occupants')
-    parser.add_argument('propertyID')
-    parser.add_argument('tenantID')
-    parser.add_argument('dateTimeStart')
-    parser.add_argument('dateTimeEnd')
-    parser.add_argument('dateUpdated')
-
     @jwt_required
     def get(self, id):
         return LeaseModel.find(id).json()
 
     @jwt_required
     def put(self,id):
-        data = Lease.parser.parse_args()
-        update = False
-
-        baseLease = LeaseModel.find_by_id(id)
-        if not baseLease:
-            return {'message': 'Lease not found'}, 404
-
-
-        if(data.occupants):
-            baseLease.occupants = data.occupants
-            update = True
-
-        if(data.name):
-            baseLease.name = data.name
-            update = True
-
-        if(data.propertyID):
-            baseLease.propertyID = data.propertyID
-            update = True
-
-        if(data.tenantID):
-            baseLease.tenantID = data.tenantID
-            update = True
-
-        if(data.dateTimeStart):
-            baseLease.dateTimeStart = datetime.strptime(data.dateTimeStart, '%m/%d/%Y %H:%M:%S')
-            update = True
-
-        if(data.dateTimeEnd):
-            baseLease.dateTimeEnd = datetime.strptime(data.dateTimeEnd, '%m/%d/%Y %H:%M:%S')
-            update = True
-
-        if update == False:
-            return baseLease.json(), 400
-        else:
-            baseLease.dateUpdated = datetime.now()
-
-        baseLease.save_to_db()
-
-        try:
-            return baseLease.json(), 200
-        except AttributeError:
-            return {'message': 'Invalid Attribute ID'}, 404
+        return LeaseModel.update(LeaseSchema(), id, request.json).json()
 
     @jwt_required
     def delete(self, id):

--- a/resources/lease.py
+++ b/resources/lease.py
@@ -16,11 +16,7 @@ class Lease(Resource):
 
     @jwt_required
     def get(self, id):
-        lease = LeaseModel.find_by_id(id)
-        if lease:
-            return lease.json()
-
-        return {'message': 'Lease not found'}, 404
+        return LeaseModel.find(id).json()
 
     @jwt_required
     def put(self,id):

--- a/resources/lease.py
+++ b/resources/lease.py
@@ -2,17 +2,20 @@ from flask import request
 from flask_restful import Resource
 from models.lease import LeaseModel
 from schemas.lease import LeaseSchema
+from serializers.lease import LeaseSerializer
 from flask_jwt_extended import jwt_required
 
 
 class Lease(Resource):
     @jwt_required
     def get(self, id):
-        return LeaseModel.find(id).json()
+        return LeaseSerializer.serialize(LeaseModel.find(id))
 
     @jwt_required
     def put(self,id):
-        return LeaseModel.update(LeaseSchema, id, request.json).json()
+        return LeaseSerializer.serialize(
+            LeaseModel.update(LeaseSchema, id, request.json)
+        )
 
     @jwt_required
     def delete(self, id):
@@ -22,7 +25,10 @@ class Lease(Resource):
 class Leases(Resource):
     @jwt_required
     def get(self):
-        return {'Leases': [lease.json() for lease in LeaseModel.query.all()]}
+        return {'leases': LeaseSerializer.serialize(
+                LeaseModel.query.all(), many=True
+            )
+        }
 
     @jwt_required
     def post(self):

--- a/resources/lease.py
+++ b/resources/lease.py
@@ -1,8 +1,11 @@
+from flask import request
 from flask_restful import Resource, reqparse
 from models.lease import LeaseModel
+from schemas.lease import LeaseSchema
 from models.property import PropertyModel
 from datetime import datetime
 from flask_jwt_extended import jwt_required
+
 
 class Lease(Resource):
     parser = reqparse.RequestParser()
@@ -76,19 +79,5 @@ class Leases(Resource):
 
     @jwt_required
     def post(self):
-        data = Lease.parser.parse_args()
-
-        #convert strings to DateTime Object
-        try:
-            data.dateTimeStart = datetime.strptime(data.dateTimeStart, '%m/%d/%Y %H:%M:%S')
-            data.dateTimeEnd = datetime.strptime(data.dateTimeEnd, '%m/%d/%Y %H:%M:%S')
-            data.dateUpdated = datetime.now()
-        except TypeError:
-            return {'message': 'Missing Lease Information'}, 400
-
-        lease = LeaseModel(**data)
-
-        lease.save_to_db()
-
+        LeaseModel.create(LeaseSchema(), request.json)
         return {'message': 'Lease created successfully'}, 201
-

--- a/resources/lease.py
+++ b/resources/lease.py
@@ -12,7 +12,7 @@ class Lease(Resource):
 
     @jwt_required
     def put(self,id):
-        return LeaseModel.update(LeaseSchema(), id, request.json).json()
+        return LeaseModel.update(LeaseSchema, id, request.json).json()
 
     @jwt_required
     def delete(self, id):
@@ -26,5 +26,5 @@ class Leases(Resource):
 
     @jwt_required
     def post(self):
-        LeaseModel.create(LeaseSchema(), request.json)
+        LeaseModel.create(LeaseSchema, request.json)
         return {'message': 'Lease created successfully'}, 201

--- a/resources/lease.py
+++ b/resources/lease.py
@@ -9,12 +9,17 @@ from flask_jwt_extended import jwt_required
 class Lease(Resource):
     @jwt_required
     def get(self, id):
-        return LeaseSerializer.serialize(LeaseModel.find(id))
+        return LeaseSerializer.serialize(
+            LeaseModel.find(id)
+        )
 
     @jwt_required
     def put(self,id):
         return LeaseSerializer.serialize(
-            LeaseModel.update(LeaseSchema, id, request.json)
+            LeaseModel.update(
+                schema=LeaseSchema,
+                id=id,
+                payload=request.json)
         )
 
     @jwt_required
@@ -32,5 +37,8 @@ class Leases(Resource):
 
     @jwt_required
     def post(self):
-        LeaseModel.create(LeaseSchema, request.json)
+        LeaseModel.create(
+            schema=LeaseSchema,
+            payload=request.json
+        )
         return {'message': 'Lease created successfully'}, 201

--- a/resources/lease.py
+++ b/resources/lease.py
@@ -67,7 +67,7 @@ class Lease(Resource):
     @jwt_required
     def delete(self, id):
         LeaseModel.delete(id)
-        return {'message': 'Lease Removed from Database'}
+        return {'message': 'Lease deleted'}
 
 class Leases(Resource):
     @jwt_required

--- a/resources/lease.py
+++ b/resources/lease.py
@@ -66,12 +66,8 @@ class Lease(Resource):
 
     @jwt_required
     def delete(self, id):
-        lease = LeaseModel.find_by_id(id)
-        if lease:
-            lease.delete_from_db()
-            return{'message': 'Lease removed from database'}, 200
-        else:
-            return{'message': 'Lease not found'}, 404
+        LeaseModel.delete(id)
+        return {'message': 'Lease Removed from Database'}
 
 class Leases(Resource):
     @jwt_required

--- a/schemas/lease.py
+++ b/schemas/lease.py
@@ -7,6 +7,7 @@ from marshmallow import fields
 class LeaseSchema(ma.SQLAlchemyAutoSchema):
   class Meta:
     model = LeaseModel
+    include_fk = True
 
   dateTimeStart = fields.DateTime(time_format, required=True)
   dateTimeEnd = fields.DateTime(time_format, required=True)

--- a/schemas/lease.py
+++ b/schemas/lease.py
@@ -8,8 +8,8 @@ class LeaseSchema(ma.SQLAlchemyAutoSchema):
   class Meta:
     model = LeaseModel
 
-  dateTimeStart = fields.DateTime(time_format)
-  dateTimeEnd = fields.DateTime(time_format)
+  dateTimeStart = fields.DateTime(time_format, required=True)
+  dateTimeEnd = fields.DateTime(time_format, required=True)
   dateUpdated = fields.DateTime(time_format)
   created_at = fields.DateTime(time_format)
   updated_at = fields.DateTime(time_format)

--- a/schemas/lease.py
+++ b/schemas/lease.py
@@ -11,6 +11,5 @@ class LeaseSchema(ma.SQLAlchemyAutoSchema):
 
   dateTimeStart = fields.DateTime(time_format, required=True)
   dateTimeEnd = fields.DateTime(time_format, required=True)
-  dateUpdated = fields.DateTime(time_format)
   created_at = fields.DateTime(time_format)
   updated_at = fields.DateTime(time_format)

--- a/schemas/lease.py
+++ b/schemas/lease.py
@@ -16,6 +16,8 @@ class LeaseSchema(ma.SQLAlchemyAutoSchema):
     created_at = fields.DateTime(time_format)
     updated_at = fields.DateTime(time_format)
 
+    tenant = fields.Nested("TenantSchema")
+
     @validates("tenantID")
     def validate_tenantID(self, value):
         if not TenantModel.query.get(value):

--- a/schemas/lease.py
+++ b/schemas/lease.py
@@ -1,15 +1,27 @@
 from ma import ma
 from models.lease import LeaseModel
+from models.tenant import TenantModel
+from models.property import PropertyModel
 from schemas.time_format import time_format
-from marshmallow import fields
+from marshmallow import fields, validates, ValidationError
 
 
 class LeaseSchema(ma.SQLAlchemyAutoSchema):
-  class Meta:
-    model = LeaseModel
-    include_fk = True
+    class Meta:
+        model = LeaseModel
+        include_fk = True
 
-  dateTimeStart = fields.DateTime(time_format, required=True)
-  dateTimeEnd = fields.DateTime(time_format, required=True)
-  created_at = fields.DateTime(time_format)
-  updated_at = fields.DateTime(time_format)
+    dateTimeStart = fields.DateTime(time_format, required=True)
+    dateTimeEnd = fields.DateTime(time_format, required=True)
+    created_at = fields.DateTime(time_format)
+    updated_at = fields.DateTime(time_format)
+
+    @validates("tenantID")
+    def validate_tenantID(self, value):
+        if not TenantModel.query.get(value):
+            raise ValidationError(f"{value} is not a valid tenant ID")
+
+    @validates("propertyID")
+    def validate_propertyID(self, value):
+        if not PropertyModel.query.get(value):
+            raise ValidationError(f"{value} is not a valid property ID")

--- a/schemas/lease.py
+++ b/schemas/lease.py
@@ -17,6 +17,7 @@ class LeaseSchema(ma.SQLAlchemyAutoSchema):
     updated_at = fields.DateTime(time_format)
 
     tenant = fields.Nested("TenantSchema")
+    property = fields.Nested("PropertySchema")
 
     @validates("tenantID")
     def validate_tenantID(self, value):

--- a/serializers/lease/lease_serializer.py
+++ b/serializers/lease/lease_serializer.py
@@ -3,5 +3,8 @@ from schemas import LeaseSchema
 
 class LeaseSerializer:
     @staticmethod
-    def serialize(lease):
-        return LeaseSchema(exclude=("tenantID","propertyID")).dump(lease)
+    def serialize(lease, many=False):
+        return LeaseSchema(
+            many=many,
+            exclude=("tenantID","propertyID")
+        ).dump(lease)

--- a/serializers/lease/lease_serializer.py
+++ b/serializers/lease/lease_serializer.py
@@ -4,4 +4,4 @@ from schemas import LeaseSchema
 class LeaseSerializer:
     @staticmethod
     def serialize(lease):
-        return LeaseSchema().dump(lease)
+        return LeaseSchema(exclude=("tenantID","propertyID")).dump(lease)

--- a/tests/factory_fixtures/lease.py
+++ b/tests/factory_fixtures/lease.py
@@ -11,7 +11,6 @@ def lease_attributes():
             "propertyID": property.id,
             "dateTimeStart": datetime.now(),
             "dateTimeEnd": datetime.now(),
-            "dateUpdated": datetime.now(),
             "occupants": 3
         }
     yield _lease_attributes

--- a/tests/integration/test_base_model.py
+++ b/tests/integration/test_base_model.py
@@ -24,7 +24,7 @@ class TestDummyModel(BaseInterfaceTest):
         self.custom_404_msg = "Dummy not found"
 
 @pytest.mark.usefixtures('empty_test_db')
-class TestBaseModel:
+class TestUpdate:
     def setup(self):
         db.session.add(DummyModel(**{'first_name': 'Bye'}))
         db.session.commit()
@@ -53,3 +53,11 @@ class TestBaseModel:
         assert obj.first_name == 'Bye'
         assert obj.last_name == None
         assert obj.updated_at == None
+
+
+@pytest.mark.usefixtures('empty_test_db')
+class TestCreate:
+    def test_it_returns_the_created_object(self):
+        obj = DummyModel.create(DummySchema, {'first_name': 'Hello'})
+
+        assert obj.id != None

--- a/tests/integration/test_base_model.py
+++ b/tests/integration/test_base_model.py
@@ -20,7 +20,7 @@ class DummySchema(ma.SQLAlchemyAutoSchema):
 class TestDummyModel(BaseInterfaceTest):
     def setup(self):
         self.object = DummyModel(**{'first_name': 'Bye'})
-        self.schema = DummySchema()
+        self.schema = DummySchema
         self.custom_404_msg = "Dummy not found"
 
 @pytest.mark.usefixtures('empty_test_db')
@@ -31,7 +31,7 @@ class TestBaseModel:
         self.id = DummyModel.query.first().id
 
     def test_partial_update(self):
-        DummyModel.update(DummySchema(), self.id, {'last_name': 'World'})
+        DummyModel.update(DummySchema, self.id, {'last_name': 'World'})
         obj = DummyModel.query.first()
 
         assert obj.first_name == 'Bye'
@@ -39,7 +39,7 @@ class TestBaseModel:
         assert obj.updated_at != None
 
     def test_full_update(self):
-        DummyModel.update(DummySchema(), self.id, {'first_name': 'Hello', 'last_name': 'World'})
+        DummyModel.update(DummySchema, self.id, {'first_name': 'Hello', 'last_name': 'World'})
         obj = DummyModel.query.first()
 
         assert obj.first_name == 'Hello'
@@ -47,7 +47,7 @@ class TestBaseModel:
         assert obj.updated_at != None
 
     def test_no_update(self):
-        DummyModel.update(DummySchema(), self.id, {})
+        DummyModel.update(DummySchema, self.id, {})
         obj = DummyModel.query.first()
 
         assert obj.first_name == 'Bye'

--- a/tests/integration/test_base_model.py
+++ b/tests/integration/test_base_model.py
@@ -1,0 +1,55 @@
+import pytest
+
+from ma import ma
+from db import db
+from models.base_model import BaseModel
+from tests.unit.base_interface_test import BaseInterfaceTest
+
+
+class DummyModel(BaseModel):
+    __tablename__ = "fake"
+
+    id = db.Column(db.Integer, primary_key=True)
+    first_name = db.Column(db.String(100), nullable=False)
+    last_name = db.Column(db.String(100))
+
+class DummySchema(ma.SQLAlchemyAutoSchema):
+  class Meta:
+    model = DummyModel
+
+class TestDummyModel(BaseInterfaceTest):
+    def setup(self):
+        self.object = DummyModel(**{'first_name': 'Bye'})
+        self.schema = DummySchema()
+        self.custom_404_msg = "Dummy not found"
+
+@pytest.mark.usefixtures('empty_test_db')
+class TestBaseModel:
+    def setup(self):
+        db.session.add(DummyModel(**{'first_name': 'Bye'}))
+        db.session.commit()
+        self.id = DummyModel.query.first().id
+
+    def test_partial_update(self):
+        DummyModel.update(DummySchema(), self.id, {'last_name': 'World'})
+        obj = DummyModel.query.first()
+
+        assert obj.first_name == 'Bye'
+        assert obj.last_name == 'World'
+        assert obj.updated_at != None
+
+    def test_full_update(self):
+        DummyModel.update(DummySchema(), self.id, {'first_name': 'Hello', 'last_name': 'World'})
+        obj = DummyModel.query.first()
+
+        assert obj.first_name == 'Hello'
+        assert obj.last_name == 'World'
+        assert obj.updated_at != None
+
+    def test_no_update(self):
+        DummyModel.update(DummySchema(), self.id, {})
+        obj = DummyModel.query.first()
+
+        assert obj.first_name == 'Bye'
+        assert obj.last_name == None
+        assert obj.updated_at == None

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -12,7 +12,7 @@ def valid_payload(tenant_id):
 
 
 @pytest.mark.usefixtures('client_class', 'empty_test_db')
-class TestGetLease:
+class TestLease:
     def setup(self):
         self.endpoint = '/api/lease'
 
@@ -41,18 +41,16 @@ class TestGetLease:
                 ]
             }
 
-
-@pytest.mark.usefixtures('client_class', 'empty_test_db')
-class TestCreateLease:
     def test_create_lease(self, valid_header, create_tenant):
-        response = self.client.post('/api/lease', json=valid_payload(create_tenant().id), headers=valid_header)
+        response = self.client.post(
+            '/api/lease',
+            json=valid_payload(create_tenant().id),
+            headers=valid_header
+        )
 
         assert is_valid(response, 201)
         assert response.json == {'message': 'Lease created successfully'}
 
-
-@pytest.mark.usefixtures('client_class', 'empty_test_db')
-class TestDeleteLease:
     def test_delete_lease(self, valid_header, create_lease):
         lease = create_lease()
 
@@ -61,9 +59,6 @@ class TestDeleteLease:
         assert is_valid(response, 200)
         assert response.json == {'message': 'Lease deleted'}
 
-
-@pytest.mark.usefixtures('client_class', 'empty_test_db')
-class TestUpdateLease:
     def test_update_lease(self, valid_header, create_lease):
         lease = create_lease()
         response = self.client.put(

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -54,7 +54,7 @@ class TestLease:
                 headers=valid_header
             )
 
-        mock_create.assert_called_once_with(LeaseSchema, {'yes': 'ok'})
+        mock_create.assert_called_once_with(schema=LeaseSchema, payload={'yes': 'ok'})
         assert response.status_code == 201
         assert response.json == {'message': 'Lease created successfully'}
 
@@ -78,7 +78,7 @@ class TestLease:
                 headers=valid_header
             )
 
-        mock_update.assert_called_once_with(LeaseSchema, 1, {'hello': 'world'})
+        mock_update.assert_called_once_with(schema=LeaseSchema, id=1, payload={'hello': 'world'})
         assert response.status_code == 200
         assert response.json == LeaseSerializer.serialize(lease)
 

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -2,6 +2,7 @@ import pytest
 from conftest import is_valid
 from models.lease import LeaseModel
 from schemas.lease import LeaseSchema
+from serializers.lease import LeaseSerializer
 from tests.time import Time
 from unittest.mock import patch
 
@@ -21,7 +22,7 @@ class TestLease:
 
         mock_find.assert_called_once_with(1)
         assert response.status_code == 200
-        assert response.json == lease.json()
+        assert response.json == LeaseSerializer.serialize(lease)
 
     def test_get_all_leases(self, valid_header, create_lease):
         lease = create_lease()
@@ -31,9 +32,9 @@ class TestLease:
 
         assert response.status_code == 200
         assert response.json == {
-            "Leases": [
-                lease.json(),
-                second_lease.json()
+            "leases": [
+                LeaseSerializer.serialize(lease),
+                LeaseSerializer.serialize(second_lease)
             ]
         }
 
@@ -42,7 +43,7 @@ class TestLease:
 
         assert response.status_code == 200
         assert response.json == {
-            "Leases": []
+            "leases": []
         }
 
     def test_create_lease(self, valid_header):
@@ -79,7 +80,7 @@ class TestLease:
 
         mock_update.assert_called_once_with(LeaseSchema, 1, {'hello': 'world'})
         assert response.status_code == 200
-        assert response.json == lease.json()
+        assert response.json == LeaseSerializer.serialize(lease)
 
 
 @pytest.mark.usefixtures('client_class', 'empty_test_db')

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -122,28 +122,6 @@ class TestUpdateLease:
         assert is_valid(response, 404)
         assert response.json == {'message': 'Lease not found'}
 
-    def test_date_is_updated_with_valid_payload(self, valid_header, create_lease):
-        lease = create_lease()
-
-        payload = {'dateTimeEnd': Time.one_year_from_now()}
-        old_date = Time.format_date(lease.dateUpdated)
-
-        with freeze_time(Time.one_year_from_now()):
-            response = self.client.put(f'{self.endpoint}/{lease.id}', json=payload, headers=valid_header)
-
-            assert is_valid(response, 200)
-            assert response.json['dateUpdated'] != old_date
-
-    def test_updatedDate_is_left_unchanged_when_given_invalid_params(self, valid_header, create_lease):
-        lease = create_lease()
-        old_date = Time.format_date(lease.dateUpdated)
-
-        with freeze_time(Time.one_year_from_now()):
-            response = self.client.put(f'{self.endpoint}/{lease.id}', json={}, headers=valid_header)
-
-        assert is_valid(response, 400)
-        assert response.json['dateUpdated'] == old_date
-
     def test_invalid_attribute_ids(self, valid_header, create_lease):
         lease = create_lease('Hello')
 

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -135,8 +135,7 @@ class TestUpdateLease:
             }
 
         response = self.client.put(f'{self.endpoint}/{lease.id}', json=payload, headers=valid_header)
-        assert is_valid(response, 404)
-        assert response.json == {'message': 'Invalid Attribute ID'}
+        assert is_valid(response, 400)
 
     def test_valid_attrs_are_all_updated(self, valid_header, create_lease, create_tenant, create_property):
         lease = create_lease()

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -24,7 +24,7 @@ class TestLease:
                 headers=valid_header
             )
 
-        assert is_valid(response, 200)
+        assert response.status_code == 200
         assert response.json == lease.json()
 
     def test_get_all_leases(self, valid_header, create_lease):
@@ -33,13 +33,13 @@ class TestLease:
 
         response = self.client.get(self.endpoint, headers=valid_header)
 
-        assert is_valid(response, 200)
+        assert response.status_code == 200
         assert response.json == {
-                "Leases": [
-                    lease.json(),
-                    another_lease.json()
-                ]
-            }
+            "Leases": [
+                lease.json(),
+                another_lease.json()
+            ]
+        }
 
     def test_create_lease(self, valid_header, create_tenant):
         response = self.client.post(
@@ -48,7 +48,7 @@ class TestLease:
             headers=valid_header
         )
 
-        assert is_valid(response, 201)
+        assert response.status_code == 201
         assert response.json == {'message': 'Lease created successfully'}
 
     def test_delete_lease(self, valid_header, create_lease):
@@ -56,7 +56,7 @@ class TestLease:
 
         response = self.client.delete(f'/api/lease/{lease.id}', headers=valid_header)
 
-        assert is_valid(response, 200)
+        assert response.status_code == 200
         assert response.json == {'message': 'Lease deleted'}
 
     def test_update_lease(self, valid_header, create_lease):
@@ -67,7 +67,7 @@ class TestLease:
             headers=valid_header
         )
 
-        assert is_valid(response, 200)
+        assert response.status_code == 200
         assert response.json['name'] == 'I'
 
 
@@ -77,100 +77,95 @@ class TestLeaseAuthorizations:
     def test_unauthorized_get_request(self):
         response = self.client.get('/api/lease/1')
 
-        assert is_valid(response, 401)
-        assert response.json == {'message': 'Missing authorization header'}
+        assert response.status_code == 401
 
     def test_unauthorized_get_all_request(self):
         response = self.client.get('/api/lease')
 
-        assert is_valid(response, 401)
-        assert response.json == {'message': 'Missing authorization header'}
+        assert response.status_code == 401
 
     def test_unauthorized_create_request(self):
         response = self.client.post('/api/lease')
 
-        assert is_valid(response, 401)
-        assert response.json == {'message': 'Missing authorization header'}
+        assert response.status_code == 401
 
     def test_unauthorized_delete_request(self):
         response = self.client.delete('/api/lease/1')
 
-        assert is_valid(response, 401)
-        assert response.json == {'message': 'Missing authorization header'}
+        assert response.status_code == 401
 
     def test_unauthorized_update_request(self):
         response = self.client.put('/api/lease/1')
 
-        assert is_valid(response, 401)
-        assert response.json == {'message': 'Missing authorization header'}
+        assert response.status_code == 401
 
     # Test all roles are authorized to access each endpoint
     def test_pm_authorized_to_get(self, pm_header, create_lease):
         lease = create_lease()
 
         response = self.client.get(f'/api/lease/{lease.id}', headers=pm_header)
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_staff_are_authorized_to_get(self, staff_header, create_lease):
         lease = create_lease()
 
         response = self.client.get(f'/api/lease/{lease.id}', headers=staff_header)
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_admin_is_authorized_to_get(self, admin_header, create_lease):
         lease = create_lease()
 
         response = self.client.get(f'/api/lease/{lease.id}', headers=admin_header)
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_pm_is_authorized_to_get_all(self, pm_header, create_lease):
         lease = create_lease()
 
         response = self.client.get('/api/lease', headers=pm_header)
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_staff_are_authorized_to_get_all(self, staff_header, create_lease):
         lease = create_lease()
 
         response = self.client.get('/api/lease', headers=staff_header)
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_admin_is_authorized_to_get_all(self, admin_header, create_lease):
         lease = create_lease()
 
         response = self.client.get('/api/lease', headers=admin_header)
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_pm_is_authorized_to_create(self, pm_header, create_tenant):
         response = self.client.post('/api/lease', json=valid_payload(create_tenant().id), headers=pm_header)
 
-        assert is_valid(response, 201)
+        assert response.status_code == 201
 
     def test_staff_are_authorized_to_create(self, staff_header, create_tenant):
         response = self.client.post('/api/lease', json=valid_payload(create_tenant().id), headers=staff_header)
-        assert is_valid(response, 201)
+        assert response.status_code == 201
 
     def test_admin_is_authorized_to_create(self, admin_header, create_tenant):
         response = self.client.post('/api/lease', json=valid_payload(create_tenant().id), headers=admin_header)
-        assert is_valid(response, 201)
+        assert response.status_code == 201
 
     def test_pm_is_authorized_to_delete_lease(self, pm_header, create_lease):
         lease = create_lease()
         response = self.client.delete(f'/api/lease/{lease.id}'.format(id), headers=pm_header)
 
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_staff_are_authorized_to_delete_lease(self, staff_header, create_lease):
         lease = create_lease()
         response = self.client.delete(f'/api/lease/{lease.id}'.format(id), headers=staff_header)
 
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_admin_is_authorized_to_delete_lease(self, admin_header, create_lease):
         lease = create_lease()
         response = self.client.delete(f'/api/lease/{lease.id}'.format(id), headers=admin_header)
 
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_pm_is_authorized_to_update(self, pm_header, create_lease):
         lease = create_lease()
@@ -179,7 +174,7 @@ class TestLeaseAuthorizations:
                 'dateTimeEnd': Time.one_year_from_now()
             }
         response = self.client.put(f'/api/lease/{lease.id}', json=payload, headers=pm_header)
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_staff_authorized_to_update(self, staff_header, create_lease):
         lease = create_lease()
@@ -188,7 +183,7 @@ class TestLeaseAuthorizations:
                 'dateTimeEnd': Time.one_year_from_now()
             }
         response = self.client.put(f'/api/lease/{lease.id}', json=payload, headers=staff_header)
-        assert is_valid(response, 200)
+        assert response.status_code == 200
 
     def test_admin_authorized_to_update(self, admin_header, create_lease):
         lease = create_lease()
@@ -197,4 +192,4 @@ class TestLeaseAuthorizations:
                 'dateTimeEnd': Time.one_year_from_now()
             }
         response = self.client.put(f'/api/lease/{lease.id}', json=payload, headers=admin_header)
-        assert is_valid(response, 200)
+        assert response.status_code == 200

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -85,11 +85,12 @@ class TestLease:
 
 @pytest.mark.usefixtures('client_class', 'empty_test_db')
 class TestLeaseAuthorizations:
-    def valid_payload(self, tenant_id):
+    def valid_payload(self, tenant_id, property_id):
         return {
                 'dateTimeStart': Time.today(),
                 'dateTimeEnd': Time.one_year_from_now(),
-                'tenantID': tenant_id
+                'tenantID': tenant_id,
+                'propertyID': property_id
             }
 
     # Test auth is in place at each endpoint
@@ -155,17 +156,17 @@ class TestLeaseAuthorizations:
         response = self.client.get('/api/lease', headers=admin_header)
         assert response.status_code == 200
 
-    def test_pm_is_authorized_to_create(self, pm_header, create_tenant):
-        response = self.client.post('/api/lease', json=self.valid_payload(create_tenant().id), headers=pm_header)
+    def test_pm_is_authorized_to_create(self, pm_header, create_tenant, create_property):
+        response = self.client.post('/api/lease', json=self.valid_payload(create_tenant().id, create_property().id), headers=pm_header)
 
         assert response.status_code == 201
 
-    def test_staff_are_authorized_to_create(self, staff_header, create_tenant):
-        response = self.client.post('/api/lease', json=self.valid_payload(create_tenant().id), headers=staff_header)
+    def test_staff_are_authorized_to_create(self, staff_header, create_tenant, create_property):
+        response = self.client.post('/api/lease', json=self.valid_payload(create_tenant().id, create_property().id), headers=staff_header)
         assert response.status_code == 201
 
-    def test_admin_is_authorized_to_create(self, admin_header, create_tenant):
-        response = self.client.post('/api/lease', json=self.valid_payload(create_tenant().id), headers=admin_header)
+    def test_admin_is_authorized_to_create(self, admin_header, create_tenant, create_property):
+        response = self.client.post('/api/lease', json=self.valid_payload(create_tenant().id, create_property().id), headers=admin_header)
         assert response.status_code == 201
 
     def test_pm_is_authorized_to_delete_lease(self, pm_header, create_lease):

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -86,9 +86,8 @@ class TestCreateLease:
 
     def test_authorized_request_with_invalid_payload(self, valid_header):
         response = self.client.post(self.endpoint, json=self.invalid_payload, headers=valid_header)
-        
+
         assert is_valid(response, 400)
-        assert response.json == {'message': 'Missing Lease Information'}
 
 
 @pytest.mark.usefixtures('client_class', 'empty_test_db')

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -102,7 +102,7 @@ class TestDeleteLease:
         response = self.client.delete(f'{self.endpoint}/{lease.id}', headers=valid_header)
 
         assert is_valid(response, 200)
-        assert response.json == {'message': 'Lease removed from database'}
+        assert response.json == {'message': 'Lease deleted'}
         assert len(LeaseModel.query.all()) == 0
 
     def test_authorized_request_with_invalid_lease_id(self, valid_header):

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -1,5 +1,4 @@
 import pytest
-from conftest import is_valid
 from models.lease import LeaseModel
 from schemas.lease import LeaseSchema
 from serializers.lease import LeaseSerializer

--- a/tests/schemas/test_lease_schema.py
+++ b/tests/schemas/test_lease_schema.py
@@ -5,11 +5,12 @@ from tests.time import Time
 
 
 class TestLeaseValidations:
-    def test_valid_payload(self, empty_test_db, create_tenant):
+    def test_valid_payload(self, empty_test_db, create_tenant, create_property):
         valid_payload = {
             'dateTimeStart': Time.today(),
             'dateTimeEnd': Time.one_year_from_now(),
-            'tenantID': create_tenant().id
+            'tenantID': create_tenant().id,
+            'propertyID': create_property().id
         }
 
         no_validation_errors = {}
@@ -72,6 +73,11 @@ class TestLeaseValidations:
         validation_errors = LeaseSchema().validate({})
 
         assert 'tenantID' in validation_errors
+
+    def test_propertyID_is_required(self):
+        validation_errors = LeaseSchema().validate({})
+
+        assert 'propertyID' in validation_errors
 
 
 @pytest.mark.usefixtures('empty_test_db')

--- a/tests/schemas/test_lease_schema.py
+++ b/tests/schemas/test_lease_schema.py
@@ -55,3 +55,8 @@ class TestLeaseValidations:
         )
 
         assert 'updated_at' in validation_errors
+
+    def test_tenantID_is_required(self):
+        validation_errors = LeaseSchema().validate({})
+
+        assert 'tenantID' in validation_errors

--- a/tests/schemas/test_lease_schema.py
+++ b/tests/schemas/test_lease_schema.py
@@ -1,0 +1,57 @@
+from schemas import LeaseSchema
+from datetime import datetime
+from tests.time import Time
+
+
+class TestLeaseValidations:
+    def test_dateTimeStart_is_required(self):
+        validation_errors = LeaseSchema().validate({})
+
+        assert 'dateTimeStart' in validation_errors
+
+    def test_dateTimeStart_validates_valid_format(self):
+        validation_errors = LeaseSchema().validate(
+            {'dateTimeStart': Time.today()}
+        )
+
+        assert 'dateTimeStart' not in validation_errors
+
+    def test_dateTimeStart_with_invalid_format(self):
+        validation_errors = LeaseSchema().validate(
+            {'dateTimeStart': Time.format_date_by_year(datetime.now())}
+        )
+
+        assert 'dateTimeStart' in validation_errors
+
+    def test_dateTimeEnd_is_required(self):
+        validation_errors = LeaseSchema().validate({})
+
+        assert 'dateTimeEnd' in validation_errors
+
+    def test_dateTimeEnd_validates_valid_date_format(self):
+        validation_errors = LeaseSchema().validate(
+            {'dateTimeEnd': Time.today()}
+        )
+
+        assert 'dateTimeEnd' not in validation_errors
+
+    def test_dateTimeEnd_with_invalid_date_format(self):
+        validation_errors = LeaseSchema().validate(
+            {'dateTimeEnd': Time.format_date_by_year(datetime.now())}
+        )
+
+        assert 'dateTimeEnd' in validation_errors
+
+    def test_created_at_is_dump_only(self):
+        validation_errors = LeaseSchema().validate(
+            {'created_at': Time.format_date_by_year(datetime.now())}
+        )
+
+        assert 'created_at' in validation_errors
+
+    def test_updated_at_is_dump_only(self):
+        validation_errors = LeaseSchema().validate(
+            {'updated_at': Time.format_date_by_year(datetime.now())}
+        )
+
+        assert 'updated_at' in validation_errors

--- a/tests/schemas/test_lease_schema.py
+++ b/tests/schemas/test_lease_schema.py
@@ -5,6 +5,17 @@ from tests.time import Time
 
 
 class TestLeaseValidations:
+    def test_valid_payload(self, empty_test_db, create_tenant):
+        valid_payload = {
+            'dateTimeStart': Time.today(),
+            'dateTimeEnd': Time.one_year_from_now(),
+            'tenantID': create_tenant().id
+        }
+
+        no_validation_errors = {}
+
+        assert no_validation_errors == LeaseSchema().validate(valid_payload)
+
     def test_dateTimeStart_is_required(self):
         validation_errors = LeaseSchema().validate({})
 

--- a/tests/schemas/test_lease_schema.py
+++ b/tests/schemas/test_lease_schema.py
@@ -1,3 +1,4 @@
+import pytest
 from schemas import LeaseSchema
 from datetime import datetime
 from tests.time import Time
@@ -60,3 +61,16 @@ class TestLeaseValidations:
         validation_errors = LeaseSchema().validate({})
 
         assert 'tenantID' in validation_errors
+
+
+@pytest.mark.usefixtures('empty_test_db')
+class TestForeignKeyValidations:
+    def test_tenantID_must_be_valid(self):
+        validation_errors = LeaseSchema().validate({'tenantID': '500'})
+
+        assert 'tenantID' in validation_errors
+
+    def test_propertyID_must_be_valid(self):
+        validation_errors = LeaseSchema().validate({'propertyID': '500'})
+
+        assert 'propertyID' in validation_errors

--- a/tests/serializers/lease/test_lease_serializer.py
+++ b/tests/serializers/lease/test_lease_serializer.py
@@ -1,5 +1,6 @@
 import pytest
 from serializers.lease import LeaseSerializer
+from serializers.tenant import TenantSerializer
 from tests.time import Time
 
 
@@ -15,5 +16,6 @@ class TestLeaseSerializer:
                 'dateTimeEnd': Time.format_date(lease.dateTimeEnd),
                 'occupants': lease.occupants,
                 'created_at': Time.format_date(lease.created_at),
-                'updated_at': Time.format_date(lease.updated_at)
+                'updated_at': Time.format_date(lease.updated_at),
+                'tenant': TenantSerializer.serialize(lease.tenant)
             }

--- a/tests/serializers/lease/test_lease_serializer.py
+++ b/tests/serializers/lease/test_lease_serializer.py
@@ -1,6 +1,7 @@
 import pytest
 from serializers.lease import LeaseSerializer
 from serializers.tenant import TenantSerializer
+from serializers.property import PropertySerializer
 from tests.time import Time
 
 
@@ -17,5 +18,6 @@ class TestLeaseSerializer:
                 'occupants': lease.occupants,
                 'created_at': Time.format_date(lease.created_at),
                 'updated_at': Time.format_date(lease.updated_at),
-                'tenant': TenantSerializer.serialize(lease.tenant)
+                'tenant': TenantSerializer.serialize(lease.tenant),
+                'property': PropertySerializer.serialize(lease.property)
             }

--- a/tests/serializers/lease/test_lease_serializer.py
+++ b/tests/serializers/lease/test_lease_serializer.py
@@ -13,7 +13,6 @@ class TestLeaseSerializer:
                 'name': lease.name,
                 'dateTimeStart': Time.format_date(lease.dateTimeStart),
                 'dateTimeEnd': Time.format_date(lease.dateTimeEnd),
-                'dateUpdated': Time.format_date(lease.dateUpdated),
                 'occupants': lease.occupants,
                 'created_at': Time.format_date(lease.created_at),
                 'updated_at': Time.format_date(lease.updated_at)

--- a/tests/time.py
+++ b/tests/time.py
@@ -8,6 +8,10 @@ class Time:
         return date.strftime("%m/%d/%Y %H:%M:%S") if date else None
 
     @staticmethod
+    def format_date_by_year(date):
+        return date.strftime("%Y/%m/%d %H:%M:%S")
+
+    @staticmethod
     def today():
         return Time.format_date(datetime.today())
 

--- a/tests/unit/base_interface_test.py
+++ b/tests/unit/base_interface_test.py
@@ -33,9 +33,3 @@ class BaseInterfaceTest:
             self.object.__class__.find(1)
 
         mock_query.get_or_404.assert_called_with(1, self.custom_404_msg)
-
-    def test_json(self):
-        with patch.object(self.object, 'json') as mock_json:
-            self.object.json()
-
-        mock_json.assert_called()

--- a/tests/unit/base_interface_test.py
+++ b/tests/unit/base_interface_test.py
@@ -6,6 +6,7 @@ from marshmallow import ValidationError, EXCLUDE
 from werkzeug.exceptions import BadRequest
 
 
+@pytest.mark.usefixtures('empty_test_db')
 class BaseInterfaceTest:
     @patch.object(db, 'session')
     def test_save_to_db(self, mock_session):

--- a/tests/unit/base_interface_test.py
+++ b/tests/unit/base_interface_test.py
@@ -41,12 +41,14 @@ class BaseInterfaceTest:
     @patch.object(db, 'session')
     def test_create_with_valid_attributes(self, mock_session):
         with patch.object(self.schema, 'load', return_value={}) as mock_load:
-            self.object.__class__.create(self.schema, {})
+            response = self.object.__class__.create(self.schema, {})
 
         mock_load.assert_called_with({}, unknown=EXCLUDE)
 
         mock_session.add.assert_called()
         mock_session.commit.assert_called()
+
+        assert response
 
     @patch.object(db, 'session')
     def test_create_with_invalid_attributes(self, mock_session):

--- a/tests/unit/test_base_model.py
+++ b/tests/unit/test_base_model.py
@@ -7,4 +7,4 @@ class TestBaseModel(BaseInterfaceTest):
     def setup(self):
         self.object = BaseModel()
         self.custom_404_msg = 'Base not found'
-        self.schema = Schema()
+        self.schema = Schema

--- a/tests/unit/test_base_model.py
+++ b/tests/unit/test_base_model.py
@@ -1,6 +1,7 @@
 from db import db
 from models.base_model import BaseModel
 from tests.unit.base_interface_test import BaseInterfaceTest
+from marshmallow import Schema
 
 
 class TestBaseModel(BaseInterfaceTest):
@@ -8,3 +9,4 @@ class TestBaseModel(BaseInterfaceTest):
     def setup(self):
         self.object = BaseModel()
         self.custom_404_msg = 'Base not found'
+        self.schema = Schema()

--- a/tests/unit/test_base_model.py
+++ b/tests/unit/test_base_model.py
@@ -1,11 +1,9 @@
-from db import db
 from models.base_model import BaseModel
 from tests.unit.base_interface_test import BaseInterfaceTest
 from marshmallow import Schema
 
 
 class TestBaseModel(BaseInterfaceTest):
-
     def setup(self):
         self.object = BaseModel()
         self.custom_404_msg = 'Base not found'

--- a/tests/unit/test_lease.py
+++ b/tests/unit/test_lease.py
@@ -1,9 +1,6 @@
-import pytest
 from tests.unit.base_interface_test import BaseInterfaceTest
 from models.lease import LeaseModel
 from schemas.lease import LeaseSchema
-from tests.time import Time
-from models.property import PropertyModel
 
 
 class TestBaseLeaseModel(BaseInterfaceTest):

--- a/tests/unit/test_lease.py
+++ b/tests/unit/test_lease.py
@@ -6,10 +6,9 @@ from tests.time import Time
 from models.property import PropertyModel
 
 
-@pytest.mark.usefixtures('test_database')
 class TestBaseLeaseModel(BaseInterfaceTest):
     def setup(self):
-        self.object = LeaseModel.query.first()
+        self.object = LeaseModel()
         self.custom_404_msg = 'Lease not found'
         self.schema = LeaseSchema()
 

--- a/tests/unit/test_lease.py
+++ b/tests/unit/test_lease.py
@@ -25,6 +25,5 @@ class TestLeaseModel():
                 'tenantID': lease.tenant.json(),
                 'dateTimeStart': Time.format_date(lease.dateTimeStart),
                 'dateTimeEnd': Time.format_date(lease.dateTimeEnd),
-                'dateUpdated': Time.format_date(lease.dateUpdated),
                 'occupants': lease.occupants
             }

--- a/tests/unit/test_lease.py
+++ b/tests/unit/test_lease.py
@@ -10,7 +10,7 @@ class TestBaseLeaseModel(BaseInterfaceTest):
     def setup(self):
         self.object = LeaseModel()
         self.custom_404_msg = 'Lease not found'
-        self.schema = LeaseSchema()
+        self.schema = LeaseSchema
 
 @pytest.mark.usefixtures('empty_test_db')
 class TestLeaseModel():

--- a/tests/unit/test_lease.py
+++ b/tests/unit/test_lease.py
@@ -1,28 +1,29 @@
 import pytest
 from tests.unit.base_interface_test import BaseInterfaceTest
 from models.lease import LeaseModel
+from schemas.lease import LeaseSchema
 from tests.time import Time
-from models.user import UserModel
 from models.property import PropertyModel
-from models.tenant import TenantModel
 
 
 @pytest.mark.usefixtures('test_database')
-class TestLeaseModel(BaseInterfaceTest):
+class TestBaseLeaseModel(BaseInterfaceTest):
     def setup(self):
-        self.object = LeaseModel.find(1)
+        self.object = LeaseModel.query.first()
         self.custom_404_msg = 'Lease not found'
+        self.schema = LeaseSchema()
 
-    def test_json(self):
-        lease = LeaseModel.find_by_id(1)
+@pytest.mark.usefixtures('empty_test_db')
+class TestLeaseModel():
+    def test_json(self, create_lease):
+        lease = create_lease()
         property = PropertyModel.find_by_id(lease.propertyID)
-        tenant = TenantModel.find_by_id(lease.tenantID)
 
         assert lease.json() == {
                 'id': lease.id,
                 'name': lease.name,
                 'propertyID': property.json(),
-                'tenantID': tenant.json(),
+                'tenantID': lease.tenant.json(),
                 'dateTimeStart': Time.format_date(lease.dateTimeStart),
                 'dateTimeEnd': Time.format_date(lease.dateTimeEnd),
                 'dateUpdated': Time.format_date(lease.dateUpdated),

--- a/tests/unit/test_lease.py
+++ b/tests/unit/test_lease.py
@@ -11,19 +11,3 @@ class TestBaseLeaseModel(BaseInterfaceTest):
         self.object = LeaseModel()
         self.custom_404_msg = 'Lease not found'
         self.schema = LeaseSchema
-
-@pytest.mark.usefixtures('empty_test_db')
-class TestLeaseModel():
-    def test_json(self, create_lease):
-        lease = create_lease()
-        property = PropertyModel.find_by_id(lease.propertyID)
-
-        assert lease.json() == {
-                'id': lease.id,
-                'name': lease.name,
-                'propertyID': property.json(),
-                'tenantID': lease.tenant.json(),
-                'dateTimeStart': Time.format_date(lease.dateTimeStart),
-                'dateTimeEnd': Time.format_date(lease.dateTimeEnd),
-                'occupants': lease.occupants
-            }


### PR DESCRIPTION
Refactor the lease endpoint.
Removes dependency on the deprecated Reqparse and uses Marshmallow for validation, serialization, and deserialization
Makes use of new abstractions, The `find`, `create`, `update`, and `delete` methods to remove logic out of the endpoints.

Implements validation on foreign keys which was previously not being done, and introduces validation tests.

This is only an example, and making use of this example and the new methods for interacting with the db should reduce complexity, and bugs. This is by no means a perfect example of what should always be done, and can most likely be improved and refactored in the future. There is probably a better a way to do this so please let me know your thoughts or else.

Resolves codeforpdx/dwellingly-app/issues/359
Resolves codeforpdx/dwellingly-app/issues/360 