### PR TITLE
Added unique constraint @ db level to User email

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -20,7 +20,7 @@ class UserModel(BaseModel):
     __tablename__ = 'users'
 
     id = db.Column(db.Integer, primary_key=True)
-    email = db.Column(db.String(100), unique=True)
+    email = db.Column(db.String(100), unique=True, nullable=False)
     role = db.Column(db.Enum(RoleEnum), default=RoleEnum.PENDING)
     firstName = db.Column(db.String(80))
     lastName = db.Column(db.String(80))

--- a/models/user.py
+++ b/models/user.py
@@ -20,7 +20,7 @@ class UserModel(BaseModel):
     __tablename__ = 'users'
 
     id = db.Column(db.Integer, primary_key=True)
-    email = db.Column(db.String(100))
+    email = db.Column(db.String(100), unique=True)
     role = db.Column(db.Enum(RoleEnum), default=RoleEnum.PENDING)
     firstName = db.Column(db.String(80))
     lastName = db.Column(db.String(80))

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -3,6 +3,7 @@ from conftest import is_valid, log
 from freezegun import freeze_time
 from models.user import RoleEnum
 from flask_jwt_extended import create_access_token, create_refresh_token
+import pytest
 
 plaintext_password = "1234"
 
@@ -200,7 +201,13 @@ def test_patch_user(client, auth_headers, new_user):
     assert changeOwnRoleResponse.json == \
             {'message': 'Only admins can change roles'}
 
-
+def test_unique_user_constraint(client, auth_headers, new_user):
+    """Emails must be unique, otherwise an Exception is thrown"""
+    with pytest.raises(Exception) as e_info:
+        userToPatch = UserModel.find_by_email(new_user.email)
+        response = client.patch(f"/api/user/{userToPatch.id}",
+                           json = {"email": "user1@dwellingly.org"},
+                           headers=auth_headers["admin"])
 
 def test_delete_user(client, auth_headers, new_user):
     userToDelete = UserModel.find_by_email(new_user.email)


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/333 

Attempting to add a duplicate email in the User model now results in an exception. I didn't see any other field that required a constraint. 

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? No
Any new dependencies to install? No
Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
