### PR TITLE
BUG: User can change password without inputting the correct current password

### DIFF
--- a/resources/user.py
+++ b/resources/user.py
@@ -112,7 +112,7 @@ class User(Resource):
             return {"message": "New password does not match."}, 422
 
           # Step #3: Set the new password
-          user.hash_digest = UserModel.hash_pw(data['new_password'])
+          user.password = data['new_password']
 
         user.save_to_db()
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -7,6 +7,7 @@ import pytest
 from utils.time import time_format
 
 plaintext_password = "1234"
+new_password = "newPassword"
 
 def test_user_auth(client, test_database, admin_user):
     login_response = client.post("/api/login", json={
@@ -142,8 +143,7 @@ def test_patch_user(client, auth_headers, new_user):
     payload = {
         'role':  RoleEnum.PROPERTY_MANAGER.value,
         'email': 'patch@test.com',
-        'phone': '503-867-5309',
-        'password': 'NewPassword'
+        'phone': '503-867-5309'
     }
 
     userToPatch = UserModel.find_by_email(new_user.email)
@@ -158,6 +158,24 @@ def test_patch_user(client, auth_headers, new_user):
     assert payload["role"] == actualRole
     assert payload["email"] == actualEmail
     assert payload["phone"] == actualPhone
+
+    """The server responds with a 401 if a patch for a pw reset is made and the current pw does not match the pw in the db"""
+    responseInvalidCurrentPassword = client.patch(f"api/user/{userToPatch.id}",
+        json={"current_password": "incorrect", "new_password": new_password, "confirm_password": new_password},
+        headers=auth_headers["admin"])
+    assert responseInvalidCurrentPassword.status_code == 401
+
+    """The server responds with a 422 if a patch for a pw reset is made and the current pw matches but the new and confirm pw does not"""
+    responseInvalidConfirmPassword = client.patch(f"api/user/{userToPatch.id}",
+        json={"current_password": plaintext_password, "new_password": new_password, "confirm_password": "not_new_password"},
+        headers=auth_headers["admin"])
+    assert responseInvalidConfirmPassword.status_code == 422
+
+    """The server responds with a 201 if a patch for a pw reset is made and the current pw matches the pw in the db"""
+    responseValidCurrentPassword = client.patch(f"api/user/{userToPatch.id}",
+        json={"current_password": plaintext_password, "new_password": new_password, "confirm_password": new_password},
+        headers=auth_headers["admin"])
+    assert responseValidCurrentPassword.status_code == 201
 
     """The server responds with an error if a non-existent user id is used for the patch user by id route."""
     responseInvalidId = client.patch("/api/user/999999", json={"role": "new_role"}, headers=auth_headers["admin"])


### PR DESCRIPTION
### What issue is this solving?
<!-- replace 340 with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. --> 
Closes codeforpdx/dwellingly-app/issues/340

Fixes bug where passwords are not checked against the database password on password reset.

### Any helpful knowledge/context for the reviewer?

I think there needs to be some frontend changes to accompany this PR. I grokked code in the front end - and as far as I can tell - although we make the user provide the current password along with the new password - I don't think the current password is ever sent to the backend for any sort of comparison. 

So the patch /user/:id endpoint only takes the new password - regardless if the current password matches or not. If someone in the frontend can confirm this - the changePassword component will now have to send in both the current password as well as the new password to the patch request and we will need to create a ticket for that work.

Is a re-seeding of the database necessary?

No

Any new dependencies to install?

No

Any special requirements to test?

None, unless I missed something
 
### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
