### PR TITLE
Add secret key env var to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.8"
+env:
+  - SECRET_KEY=somethinghereforciprtoexecuteintestbuilds
 install:
   - pip install pipenv --upgrade-strategy=only-if-needed
   - pipenv install --dev


### PR DESCRIPTION
# Description

Moving this from a protected env var to a public env var in the config
so that Pull Requests from forks can run without issue. This secret key
is for tests, and a different key is used for production; hence it is
not a security issue.