### PR TITLE
Added enum for ticket status

### DIFF
--- a/data/seedData.py
+++ b/data/seedData.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from models.user import UserModel, RoleEnum
 from models.property import PropertyModel
 from models.tenant import TenantModel
-from models.tickets import TicketModel
+from models.tickets import TicketModel, TicketStatus
 from models.notes import NotesModel
 from models.revoked_tokens import RevokedTokensModel
 from models.emergency_contact import EmergencyContactModel
@@ -170,28 +170,28 @@ def seedData():
         issue="The roof, the roof, the roof is on fire.",
         tenant=tenant_renty_mcrenter.id,
         sender=user_1.id,
-        status="In Progress",
+        status=TicketStatus.In_Progress,
         urgency="Low",
         assignedUser=user_mister_sir.id)
     ticket_roof_on_fire.save_to_db()
     ticket_dumpster_fire = TicketModel(issue="Flaming Dumpster Fire.",
                                        tenant=tenant_soho_muless.id,
                                        sender=user_3.id,
-                                       status="New",
+                                       status=TicketStatus.New,
                                        urgency="Critical",
                                        assignedUser=user_mister_sir.id)
     ticket_dumpster_fire.save_to_db()
     ticket_unpaid_rent = TicketModel(issue="Unpaid Rent",
                                      tenant=tenant_renty_mcrenter.id,
                                      sender=user_1.id,
-                                     status="New",
+                                     status=TicketStatus.New,
                                      urgency="High",
                                      assignedUser=user_mister_sir.id)
     ticket_unpaid_rent.save_to_db()
     ticket_40_cats = TicketModel(issue="Over 40 cats in domicile.",
                                  tenant=tenant_soho_muless.id,
                                  sender=user_3.id,
-                                 status="Closed",
+                                 status=TicketStatus.Closed,
                                  urgency="Low",
                                  assignedUser=user_mister_sir.id)
     ticket_40_cats.save_to_db()

--- a/models/tickets.py
+++ b/models/tickets.py
@@ -7,7 +7,12 @@ from models.tenant import TenantModel
 from datetime import datetime, timedelta
 from models.base_model import BaseModel
 from utils.time import Time
+import enum
 
+class TicketStatus(str, enum.Enum):
+    New: str = "New"
+    In_Progress: str = "In Progress"
+    Closed: str = "Closed"
 
 class TicketModel(BaseModel):
     __tablename__ = "tickets"
@@ -18,7 +23,7 @@ class TicketModel(BaseModel):
     assignedUser = db.Column(db.Integer, db.ForeignKey('users.id'))
     sender = db.Column(db.Integer, db.ForeignKey('users.id'))
     minsPastUpdate = db.Column(db.Integer, default=0)
-    status = db.Column(db.String(12))
+    status = db.Column(db.Enum(TicketStatus))
     urgency = db.Column(db.String(12))
     notelog = db.Column(db.Text)
 

--- a/models/tickets.py
+++ b/models/tickets.py
@@ -10,9 +10,9 @@ from utils.time import Time
 import enum
 
 class TicketStatus(str, enum.Enum):
-    New: str = "New"
-    In_Progress: str = "In Progress"
-    Closed: str = "Closed"
+    New = "New"
+    In_Progress = "In Progress"
+    Closed = "Closed"
 
 class TicketModel(BaseModel):
     __tablename__ = "tickets"

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -37,7 +37,7 @@ def test_tickets_GET_one(client, test_database, auth_headers):
     assert response.json['assignedUserID'] == 4
     assert response.json['sender'] == 'user1 tester'
     assert response.json['assigned'] == 'Mr. Sir'
-    assert response.json['status'] == 'In Progress'
+    assert response.json['status'] == TicketStatus.In_Progress
     assert response.json['urgency'] == 'Low'
     assert len(response.json['notes']) == 2
     assert response.json['notes'][0]['ticketid'] == 1
@@ -75,7 +75,7 @@ def test_tickets_POST(client, auth_headers):
     assert response.json['assignedUserID'] == 4
     assert response.json['sender'] == 'user1 tester'
     assert response.json['assigned'] == 'Mr. Sir'
-    assert response.json['status'] == 'New'
+    assert response.json['status'] == TicketStatus.New
     assert response.json['urgency'] == 'low'
     assert response.json['created_at'] == dt.strftime(time_format)
 
@@ -108,7 +108,7 @@ def test_tickets_PUT(client, auth_headers):
     assert response.json['assignedUserID'] == 3
     assert response.json['sender'] == 'user2 tester'
     assert response.json['assigned'] == 'user3 tester'
-    assert response.json['status'] == 'In Progress'
+    assert response.json['status'] == TicketStatus.In_Progress
     assert response.json['urgency'] == 'high'
     # Ticket already had 2 notes to begin with - and with this PUT - it's +1
     assert len(response.json['notes']) == 3

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from freezegun import freeze_time
 from unittest.mock import patch
 from utils.time import time_format
+from models.tickets import TicketStatus
 
 endpoint = '/api/tickets'
 validID = 1
@@ -36,7 +37,7 @@ def test_tickets_GET_one(client, test_database, auth_headers):
     assert response.json['assignedUserID'] == 4
     assert response.json['sender'] == 'user1 tester'
     assert response.json['assigned'] == 'Mr. Sir'
-    assert response.json['status'] == 'In Progress'
+    assert response.json['status'] == TicketStatus.In_Progress
     assert response.json['urgency'] == 'Low'
     assert len(response.json['notes']) == 2
     assert response.json['notes'][0]['ticketid'] == 1
@@ -55,7 +56,7 @@ def test_tickets_POST(client, auth_headers):
     newTicket = {
         'sender': 1,
         'tenant': 1,
-        'status': 'new',
+        'status': TicketStatus.New,
         'urgency': 'low',
         'issue': 'Lead paint issue',
         "assignedUser": 4,
@@ -74,7 +75,7 @@ def test_tickets_POST(client, auth_headers):
     assert response.json['assignedUserID'] == 4
     assert response.json['sender'] == 'user1 tester'
     assert response.json['assigned'] == 'Mr. Sir'
-    assert response.json['status'] == 'new'
+    assert response.json['status'] == TicketStatus.New
     assert response.json['urgency'] == 'low'
     assert response.json['created_at'] == dt.strftime(time_format)
 
@@ -88,7 +89,7 @@ def test_tickets_PUT(client, auth_headers):
         'sender': 2,
         'tenant': 2,
         'assignedUser': 3,
-        'status': 'in progress',
+        'status': TicketStatus.In_Progress,
         'urgency': 'high',
         'issue': 'Leaky pipe',
         'note': 'Tenant has a service dog'
@@ -107,7 +108,7 @@ def test_tickets_PUT(client, auth_headers):
     assert response.json['assignedUserID'] == 3
     assert response.json['sender'] == 'user2 tester'
     assert response.json['assigned'] == 'user3 tester'
-    assert response.json['status'] == 'in progress'
+    assert response.json['status'] == TicketStatus.In_Progress
     assert response.json['urgency'] == 'high'
     # Ticket already had 2 notes to begin with - and with this PUT - it's +1
     assert len(response.json['notes']) == 3

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -37,7 +37,7 @@ def test_tickets_GET_one(client, test_database, auth_headers):
     assert response.json['assignedUserID'] == 4
     assert response.json['sender'] == 'user1 tester'
     assert response.json['assigned'] == 'Mr. Sir'
-    assert response.json['status'] == TicketStatus.In_Progress
+    assert response.json['status'] == 'In Progress'
     assert response.json['urgency'] == 'Low'
     assert len(response.json['notes']) == 2
     assert response.json['notes'][0]['ticketid'] == 1
@@ -56,7 +56,7 @@ def test_tickets_POST(client, auth_headers):
     newTicket = {
         'sender': 1,
         'tenant': 1,
-        'status': TicketStatus.New,
+        'status': "New",
         'urgency': 'low',
         'issue': 'Lead paint issue',
         "assignedUser": 4,
@@ -75,7 +75,7 @@ def test_tickets_POST(client, auth_headers):
     assert response.json['assignedUserID'] == 4
     assert response.json['sender'] == 'user1 tester'
     assert response.json['assigned'] == 'Mr. Sir'
-    assert response.json['status'] == TicketStatus.New
+    assert response.json['status'] == 'New'
     assert response.json['urgency'] == 'low'
     assert response.json['created_at'] == dt.strftime(time_format)
 
@@ -89,7 +89,7 @@ def test_tickets_PUT(client, auth_headers):
         'sender': 2,
         'tenant': 2,
         'assignedUser': 3,
-        'status': TicketStatus.In_Progress,
+        'status': 'In Progress',
         'urgency': 'high',
         'issue': 'Leaky pipe',
         'note': 'Tenant has a service dog'
@@ -108,7 +108,7 @@ def test_tickets_PUT(client, auth_headers):
     assert response.json['assignedUserID'] == 3
     assert response.json['sender'] == 'user2 tester'
     assert response.json['assigned'] == 'user3 tester'
-    assert response.json['status'] == TicketStatus.In_Progress
+    assert response.json['status'] == 'In Progress'
     assert response.json['urgency'] == 'high'
     # Ticket already had 2 notes to begin with - and with this PUT - it's +1
     assert len(response.json['notes']) == 3

--- a/tests/unit/test_ticket.py
+++ b/tests/unit/test_ticket.py
@@ -1,4 +1,4 @@
-from models.tickets import TicketModel
+from models.tickets import TicketModel, TicketStatus
 from models.notes import NotesModel
 
 def test_ticket():
@@ -6,7 +6,7 @@ def test_ticket():
     testIssue = 'Property Damage'
     testSender = 'user1 tester'
     testTenant = 'Renty McRenter'
-    testStatus = 'new'
+    testStatus = TicketStatus.New
     testUrgency = 'low'
     testAssignedUser = 4
 


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/404

An enum for ticket status replaces hard coded ticket statuses.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? No
Any new dependencies to install? No
Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards
- [ x] Code builds successfully
- [ x] Code has been tested and does not produce errors
- [ x] Code is readable and formatted
- [ x] There isn't any unnecessary commented-out code
