### PR TITLE
Create work factor env var

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Default(object):
     #config DataBase
     SECRET_KEY = os.environ.get('SECRET_KEY')
+    WORK_FACTOR = 12
     JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     JWT_AUTH_USERNAME_KEY = os.environ.get('JWT_AUTH_USERNAME_KEY')
@@ -42,6 +43,7 @@ class Testing(Default):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL') or \
         'sqlite://'
+    WORK_FACTOR = 4
     JWT_ACCESS_TOKEN_EXPIRES = False
     JWT_REFRESH_TOKEN_EXPIRES = False
     MAIL_SUPPRESS_SEND = True

--- a/models/user.py
+++ b/models/user.py
@@ -1,3 +1,4 @@
+from flask import current_app
 from datetime import datetime, timedelta
 import bcrypt
 import time
@@ -74,7 +75,7 @@ class UserModel(BaseModel):
 
     @staticmethod
     def hash_pw(plaintext_password):
-        return bcrypt.hashpw(bytes(plaintext_password, 'utf-8'), bcrypt.gensalt())
+        return bcrypt.hashpw(bytes(plaintext_password, 'utf-8'), bcrypt.gensalt(current_app.config['WORK_FACTOR']))
 
     def check_pw(self, plaintext_password):
         return bcrypt.checkpw(bytes(plaintext_password, 'utf-8'), self.hash_digest)

--- a/models/user.py
+++ b/models/user.py
@@ -34,16 +34,11 @@ class UserModel(BaseModel):
     lastActive = db.Column(db.DateTime, default=datetime.utcnow)
 
 
-    def __init__(self, firstName, lastName, email, password, phone, role, archived):
-        self.firstName = firstName
-        self.lastName = lastName
-        self.email = email
-        self.phone = phone
-        self.hash_digest = UserModel.hash_pw(password)
+    def __init__(self, **kwargs):
+        super(UserModel, self).__init__(**kwargs)
+        self.hash_digest = UserModel.hash_pw(kwargs['password'])
         self._password = None
-        self.role = role
         self.archived = False
-        self.lastActive = datetime.utcnow()
 
     @property
     def password(self):
@@ -93,8 +88,8 @@ class UserModel(BaseModel):
             'created_at': Time.format_date(self.created_at),
             'updated_at': Time.format_date(self.updated_at)
         }
-    
-    def widgetJson(self, propertyName, date):          
+
+    def widgetJson(self, propertyName, date):
         return{
             'id': self.id,
             'stat': date,
@@ -109,12 +104,12 @@ class UserModel(BaseModel):
     @classmethod
     def find_by_role(cls, role):
         return cls.query.filter_by(role=role).all()
-    
+
     @classmethod
     def find_recent_role(cls, role, days):
         dateTime = datetime.utcnow() - timedelta(days = days)
         return db.session.query(UserModel).filter(UserModel.role == role).order_by(UserModel.created_at.desc()).limit(3).all()
-      
+
     @classmethod
     def find_by_role_and_name(cls, role, name):
         likeName = f'%{name}%'

--- a/tests/factory_fixtures/user.py
+++ b/tests/factory_fixtures/user.py
@@ -16,3 +16,20 @@ def create_property_manager():
         pm.save_to_db()
         return pm
     yield _create_property_manager
+
+
+@pytest.fixture
+def create_admin_user():
+    def _create_admin_user(firstName="Dwellingly", lastName="Admin"):
+        admin = UserModel(
+                email="admin@dwellingly.com",
+                password="asdf",
+                firstName=firstName,
+                lastName=lastName,
+                phone="505-503-1111",
+                role=RoleEnum.ADMIN,
+                archived=False
+            )
+        admin.save_to_db()
+        return admin
+    yield _create_admin_user

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -4,17 +4,6 @@ import jwt
 import time
 from freezegun import freeze_time
 
-adminUserEmail = "user1@dwellingly.org"
-adminRole = RoleEnum.ADMIN
-phone = "1 800-Cal-Saul"
-
-def test_admin_user():
-    """The properties must match the model's inputs."""
-    admin_user = UserModel(email=adminUserEmail, password="1234", firstName="user1", lastName="admin", phone=phone, role=adminRole, archived=0)
-    assert admin_user.email == adminUserEmail
-    assert admin_user.role == adminRole
-    assert admin_user.phone == phone
-
 @patch.object(jwt, 'encode')
 def test_reset_password_token(stubbed_encode, app, test_database):
     user = UserModel.find_by_id(1)

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -15,6 +15,6 @@ def test_reset_password_token(stubbed_encode, app, test_database):
         assert user.reset_password_token()
         stubbed_encode.assert_called_once_with(payload, app.secret_key, algorithm='HS256')
 
-def test_full_name():
-    admin_user = UserModel(email=adminUserEmail, password="1234", firstName="first", lastName="last", phone=phone, role=adminRole, archived=0)
-    assert admin_user.full_name() == 'first last'
+def test_full_name(empty_test_db, create_admin_user):
+    admin= create_admin_user(firstName='first', lastName='last')
+    assert admin.full_name() == 'first last'


### PR DESCRIPTION
Created config var to set the work factor for bcrypt dependent on which environment is running.

I'm not really a fan of this, but I think it is probably the best solution right now to get the tests back up to running at a decent speed.

There were two tests failing after this change due to the app context was not present. This was happening because the database was not being used when a user was being created in the test.
 - I removed one of the tests because it is obsolete
 - Updated the second test.
