### PR TITLE
Update hash architecture

### DIFF
--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -137,7 +137,7 @@ def test_archive_user_failure(client, auth_headers):
     assert responseInvalidId.json == \
             {'message': 'User cannot be archived'}
 
-def test_patch_user(client, auth_headers, new_user):
+def test_patch_user(client, auth_headers, new_user, create_admin_user):
     """The route to patch a user by id returns a successful response code and the expected data is patched."""
 
     payload = {
@@ -147,7 +147,7 @@ def test_patch_user(client, auth_headers, new_user):
     }
 
     userToPatch = UserModel.find_by_email(new_user.email)
-    response = client.patch(f"/api/user/{userToPatch.id}", json=payload,
+    response = client.patch(f"/api/user/{create_admin_user().id}", json=payload,
         headers=auth_headers["admin"])
 
     actualRole = int(response.json["role"])


### PR DESCRIPTION
Using a fixture in the patch test when not updating a password
exposes a bug where `_password` does not exist, because it is only
available when objects are instantiated through the UserModel's init
method, but not when they're retrieved from the database.

Submitted this PR in two commits. First commit updates the test so that you can see it fail. second commits fixes the bug.

Fixes codeforpdx/dwellingly-app/issues/429