### PR TITLE
Speed up mailer tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -51,7 +51,12 @@ def auth_headers(client, test_database, admin_user, new_user, property_manager_u
 @pytest.fixture
 def valid_header():
     token = jwt.encode(
-            {'identity': 'identity'},
+            {
+                'identity': 'identity',
+                'user_claims': {
+                    'is_admin': True
+                }
+            },
             current_app.secret_key,algorithm='HS256'
         ).decode('utf-8')
     return {"Authorization": f"Bearer {token}"}

--- a/resources/email.py
+++ b/resources/email.py
@@ -17,7 +17,7 @@ class Email(Resource):
         data = Email.parser.parse_args()
         user = UserModel.find_by_id(data.user_id)
 
-        message = Message(data.subject, sender=Email.NO_REPLY, body=data.body )
+        message = Message(data.subject, sender=Email.NO_REPLY, body=data.body)
         message.recipients = [user.email]
 
         current_app.mail.send(message)

--- a/tests/integration/test_mailers.py
+++ b/tests/integration/test_mailers.py
@@ -5,30 +5,31 @@ from flask_mail import Mail, Message
 from resources.email import Email
 
 
-@pytest.mark.usefixtures('client_class', 'test_database')
+@pytest.mark.usefixtures('client_class', 'empty_test_db')
 class TestPostEmail:
     def setup(self):
         self.endpoint = '/api/user/message'
 
     @patch.object(Mail, 'send')
-    def test_email_can_be_sent(self, send_mail_msg, auth_headers):
+    def test_email_can_be_sent(self, send_mail_msg, create_admin_user, valid_header):
         payload = {
-                'user_id': 1,
+                'user_id': create_admin_user().id,
                 'subject': 'Some email subject',
                 'body': 'Some body'
             }
 
-        response = self.client.post(
+        with patch.object(Message, '__init__', return_value=None):
+            response = self.client.post(
                 self.endpoint,
                 json=payload,
-                headers=auth_headers["admin"]
+                headers=valid_header
             )
         assert is_valid(response, 200)
         send_mail_msg.assert_called()
         assert response.json == {"message": "Message sent"}
 
     @patch.object(Mail, 'send')
-    def test_user_id_param_is_required(self, send_mail_msg, auth_headers):
+    def test_user_id_param_is_required(self, send_mail_msg, valid_header):
         payload = {
                 'subject': 'Some email subject',
                 'body': 'Some body'
@@ -36,14 +37,14 @@ class TestPostEmail:
         response = self.client.post(
                 self.endpoint,
                 json=payload,
-                headers=auth_headers["admin"]
+                headers=valid_header
             )
 
         assert response.status == '400 BAD REQUEST'
         send_mail_msg.assert_not_called()
 
     @patch.object(Mail, 'send')
-    def test_subject_param_is_required(self, send_mail_msg, auth_headers):
+    def test_subject_param_is_required(self, send_mail_msg, valid_header):
         payload = {
                 'user_id': 1,
                 'body': 'Some body'
@@ -51,14 +52,14 @@ class TestPostEmail:
         response = self.client.post(
                 self.endpoint,
                 json=payload,
-                headers=auth_headers["admin"]
+                headers=valid_header
             )
 
         assert response.status == '400 BAD REQUEST'
         send_mail_msg.assert_not_called()
 
     @patch.object(Mail, 'send')
-    def test_body_param_is_required(self, send_mail_msg, auth_headers):
+    def test_body_param_is_required(self, send_mail_msg, valid_header):
         payload = {
                 'user_id': 1,
                 'subject': 'Some email subject',
@@ -66,14 +67,14 @@ class TestPostEmail:
         response = self.client.post(
                 self.endpoint,
                 json=payload,
-                headers=auth_headers["admin"]
+                headers=valid_header
             )
 
         assert response.status == '400 BAD REQUEST'
         send_mail_msg.assert_not_called()
 
 
-@pytest.mark.usefixtures('client_class', 'test_database')
+@pytest.mark.usefixtures('client_class', 'empty_test_db')
 class TestEmailAuthorizations:
     def setup(self):
         self.endpoint = '/api/user/message'
@@ -97,9 +98,11 @@ class TestEmailAuthorizations:
                 assert response.json == {'message': "Admin access required"}
 
 
-@pytest.mark.usefixtures('test_database')
+@pytest.mark.usefixtures('empty_test_db')
 class TesttEmail:
     @patch.object(Mail, 'send')
     def test_reset_password_msg(self, send_mail_msg, new_user):
-        Email.send_reset_password_msg(new_user)
+        with patch.object(Message, '__init__', return_value=None):
+            Email.send_reset_password_msg(new_user)
+
         send_mail_msg.assert_called()


### PR DESCRIPTION
The tests were taking about 11 seconds to run on my machine. It seems
the main culprit was the flask-mail library when instantiating the
Message object. The flask-mail is deprecated, and there is a ticket to
replace that. The mailer tests now take less than a half second to run.
