### PR TITLE
Refactor RegisterUser endpoint

### DIFF
--- a/resources/user.py
+++ b/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource, reqparse
 from flask import request
-
+from schemas import UserRegisterSchema
 from models.property import PropertyModel
 from models.tenant import TenantModel
 from resources.admin_required import admin_required
@@ -20,27 +20,11 @@ class UserRoles(Resource):
         return result, 200
 
 class UserRegister(Resource):
-    parser = reqparse.RequestParser()
-    parser.add_argument('firstName',type=str,required=True,help="This field cannot be blank")
-    parser.add_argument('lastName',type=str,required=True,help="This field cannot be blank")
-    parser.add_argument('email',type=str,required=True,help="This field cannot be blank")
-    parser.add_argument('password', type=str, required=True, help="This field cannot be blank")
-    parser.add_argument('role',type=int,required=False,help="This field is not required")
-    parser.add_argument('archived',type=str,required=False,help="This field is not required")
-    parser.add_argument('phone',type=str,required=True,help="This field cannot be blank")
-
     def post(self):
-        data = UserRegister.parser.parse_args()
-
-        if UserModel.find_by_email(data['email']):
-            return {"message": "A user with that email already exists"}, 400
-
-        user = UserModel(firstName=data['firstName'],
-                         lastName=data['lastName'], email=data['email'],
-                         password=data['password'], phone=data['phone'],
-                         role=RoleEnum(data['role']) if data['role'] else None, archived=data['archived'])
-        # And we'll store it into the db as bytes
-        user.save_to_db()
+        UserModel.create(
+            schema=UserRegisterSchema,
+            payload=request.json
+        )
 
         return {"message": "User created successfully."}, 201
 

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,4 +1,4 @@
 from .lease import LeaseSchema
 from .tenant import TenantSchema
 from .property import PropertySchema
-from .user import UserSchema
+from .user import *

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -1,7 +1,7 @@
 from ma import ma
 from models.user import UserModel
 from utils.time import time_format
-from marshmallow import fields
+from marshmallow import fields, validates, ValidationError
 
 
 class UserSchema(ma.SQLAlchemyAutoSchema):
@@ -10,3 +10,16 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
 
     created_at = fields.DateTime(time_format)
     updated_at = fields.DateTime(time_format)
+
+    @validates("email")
+    def validate_uniqueness_of_email(self, value):
+        if UserModel.find_by_email(value):
+            raise ValidationError(f"A user with email '{value}' already exists")
+
+
+class UserRegisterSchema(UserSchema):
+    password = fields.String(required=True)
+
+    @validates("role")
+    def user_cannot_register_a_role(self, _):
+        raise ValidationError("Role is not allowed")

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -1,9 +1,11 @@
+import pytest
+from unittest.mock import patch
 from models.user import UserModel
+from schemas import UserRegisterSchema
 from conftest import is_valid, log
 from freezegun import freeze_time
 from models.user import RoleEnum
 from flask_jwt_extended import create_access_token, create_refresh_token
-import pytest
 from utils.time import time_format
 
 plaintext_password = "1234"
@@ -43,26 +45,6 @@ def test_last_active(client, test_database, admin_user):
         user = UserModel.find_by_email(admin_user.email)
         assert user.lastActive.strftime(time_format) == '01/01/2020 00:00:00'
 
-def test_register_duplicate_user(client, test_database):
-    """When a user first registers, the server responds successfully."""
-    genericUser = {
-        "firstName": "first",
-        "lastName": "last",
-        "password": plaintext_password,
-        "email": "email@mail.com",
-        "phone": "123 123 5555"
-    }
-    login_response = client.post("/api/register", json=genericUser)
-    assert login_response.status_code == 201
-
-    """The server responds with an error if duplicate user details are used for registration."""
-    duplicateUser = genericUser
-    responseDuplicate = client.post("/api/register", json=duplicateUser)
-    assert responseDuplicate.status_code == 400
-    assert responseDuplicate.json == \
-            {'message':
-             'A user with that email already exists'}
-
 def test_refresh_user(client, test_database, admin_user):
     login_response = client.post("/api/login", json={
         "email": admin_user.email,
@@ -84,7 +66,6 @@ def test_get_user_by_id(client, auth_headers, admin_user):
     assert responseBadUserId.status_code == 404
     assert responseBadUserId.json == \
             {'message': 'User not found'}
-
 
 def test_user_roles(client, auth_headers):
     """The get users by role route returns a successful response code."""
@@ -260,3 +241,27 @@ def test_get_user(client, auth_headers, new_user):
     assert is_valid(unauthorized_user_response, 401)
     assert unauthorized_user_response.json == \
             {'message': 'Admin access required'}
+
+
+@pytest.mark.usefixtures('client_class', 'empty_test_db')
+class TestReigsterUser:
+    def setup(self):
+        self.endpoint = "/api/register"
+        self.valid_payload = {
+            'email': 'faker.unique.email@example.com',
+            'password': 'faker.password'
+        }
+
+    def test_user_can_register_with_valid_payload(self):
+        response = self.client.post(self.endpoint, json=self.valid_payload)
+
+        assert response.status_code == 201
+
+    @patch.object(UserModel, 'create')
+    def test_user_calls_create(self, mock_create):
+        response = self.client.post(self.endpoint, json=self.valid_payload)
+
+        mock_create.assert_called_with(
+            schema=UserRegisterSchema,
+            payload=self.valid_payload
+        )

--- a/tests/schemas/test_user_schema.py
+++ b/tests/schemas/test_user_schema.py
@@ -1,13 +1,35 @@
 import pytest
-from schemas import UserSchema
+from schemas.user import *
 
 
-class TestUserValidations:
-    def test_valid_payload(self, empty_test_db, create_property_manager):
-        valid_payload = {
-            'email': create_property_manager().email
+class UserSchemaValidations:
+    def test_unique_email(self, empty_test_db, create_join_staff):
+        user = create_join_staff()
+
+        payload = {
+            'email': user.email
         }
 
-        no_validation_errors = {}
+        validation_errors = UserSchema().validate(payload)
 
-        assert no_validation_errors == UserSchema().validate(valid_payload)
+        assert 'email' in validation_errors
+        assert validation_errors['email'] == [f"A user with email '{user.email}' already exists"]
+
+
+class TestUserValidations(UserSchemaValidations):
+    pass
+
+
+class TestUserRegisterSchemaValidations(UserSchemaValidations):
+    def test_presence_of_role_key_is_not_valid(self):
+        payload = {'role': 'ADMIN'}
+
+        validation_errors = UserRegisterSchema().validate(payload)
+
+        assert 'role' in validation_errors
+        assert validation_errors['role'] == ['Role is not allowed']
+
+    def test_password_is_required(self):
+        validation_errors = UserRegisterSchema().validate({})
+
+        assert 'password' in validation_errors


### PR DESCRIPTION
Refactored UserRegister to use marshmallow for input validation. While
refactoring found a bug that would allow a bad actor to register as any
role (admin). Patched this to raise an error if the 'role' field is
submitted to the UserRegister endpoint.

Fixes codeforpdx/dwellingly-app/issues/445