### PR TITLE
435 dashboard links

### DIFF
--- a/resources/widgets.py
+++ b/resources/widgets.py
@@ -53,7 +53,8 @@ class Widgets(Resource):
             projectManagers.append(nullPropertyManager)
 
         return { 'opentickets':{
-            'title': 'Open Tickets', 
+            'title': 'Open Tickets',
+            'link': '/tickets', 
             'stats': [[
                 {
                     "stat": TicketModel.find_count_by_status("New"),
@@ -77,7 +78,7 @@ class Widgets(Resource):
         },
         'reports':{
             'title': 'Reports',
-            'link': '#',
+            'link': '/reports/',
             'stats': [
                 [ 
                     {
@@ -97,7 +98,7 @@ class Widgets(Resource):
         },
         'managers':{
                 'title': 'New Property Managers',
-                'link': '#',
+                'link': '/manage/managers/',
                 'isDate': True,
                 'stats': [projectManagers]
             }


### PR DESCRIPTION
### What issue is this solving?

Closes   #codeforpdx/dwellingly-app/issues/435

### Any helpful knowledge/context for the reviewer?

This issue requires both backend and frontend changes, since the dashboard cards somewhat inexplicably rely on backend data to construct their links. Rather than restructure anything, this pull request simply provides appropriate data on the backend.

