### PR TITLE
Update validation to use simplified iso format

### DIFF
--- a/resources/tenants.py
+++ b/resources/tenants.py
@@ -58,11 +58,6 @@ class Tenants(Resource):
 
         #if this tenant has a lease
         if ("dateTimeEnd" in leaseData and "dateTimeStart" in leaseData and "propertyID" in leaseData):
-
-            #convert dateTimeStart and dateTimeEnd from iso8601 format
-            leaseData["dateTimeStart"] = Time.format_date(datetime.fromisoformat(leaseData["dateTimeStart"]))
-            leaseData["dateTimeEnd"] = Time.format_date(datetime.fromisoformat(leaseData["dateTimeEnd"]))
-
             LeaseModel.create(
                 schema=LeaseSchema,
                 payload=leaseData

--- a/schemas/lease.py
+++ b/schemas/lease.py
@@ -2,7 +2,7 @@ from ma import ma
 from models.lease import LeaseModel
 from models.tenant import TenantModel
 from models.property import PropertyModel
-from utils.time import time_format
+from utils.time import time_format, iso_format
 from marshmallow import fields, validates, ValidationError
 
 
@@ -11,8 +11,8 @@ class LeaseSchema(ma.SQLAlchemyAutoSchema):
         model = LeaseModel
         include_fk = True
 
-    dateTimeStart = fields.DateTime(time_format, required=True)
-    dateTimeEnd = fields.DateTime(time_format, required=True)
+    dateTimeStart = fields.DateTime(iso_format, required=True)
+    dateTimeEnd = fields.DateTime(iso_format, required=True)
     created_at = fields.DateTime(time_format)
     updated_at = fields.DateTime(time_format)
 

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -86,8 +86,8 @@ class TestLease:
 class TestLeaseAuthorizations:
     def valid_payload(self, tenant_id, property_id):
         return {
-                'dateTimeStart': Time.today(),
-                'dateTimeEnd': Time.one_year_from_now(),
+                'dateTimeStart': Time.today_iso(),
+                'dateTimeEnd': Time.one_year_from_now_iso(),
                 'tenantID': tenant_id,
                 'propertyID': property_id
             }
@@ -192,8 +192,8 @@ class TestLeaseAuthorizations:
     def test_pm_is_authorized_to_update(self, pm_header, create_lease):
         lease = create_lease()
         payload = {
-                'dateTimeStart': Time.today(),
-                'dateTimeEnd': Time.one_year_from_now()
+                'dateTimeStart': Time.today_iso(),
+                'dateTimeEnd': Time.one_year_from_now_iso()
             }
         response = self.client.put(f'/api/lease/{lease.id}', json=payload, headers=pm_header)
         assert response.status_code == 200
@@ -201,8 +201,8 @@ class TestLeaseAuthorizations:
     def test_staff_authorized_to_update(self, staff_header, create_lease):
         lease = create_lease()
         payload = {
-                'dateTimeStart': Time.today(),
-                'dateTimeEnd': Time.one_year_from_now()
+                'dateTimeStart': Time.today_iso(),
+                'dateTimeEnd': Time.one_year_from_now_iso()
             }
         response = self.client.put(f'/api/lease/{lease.id}', json=payload, headers=staff_header)
         assert response.status_code == 200
@@ -210,8 +210,8 @@ class TestLeaseAuthorizations:
     def test_admin_authorized_to_update(self, admin_header, create_lease):
         lease = create_lease()
         payload = {
-                'dateTimeStart': Time.today(),
-                'dateTimeEnd': Time.one_year_from_now()
+                'dateTimeStart': Time.today_iso(),
+                'dateTimeEnd': Time.one_year_from_now_iso()
             }
         response = self.client.put(f'/api/lease/{lease.id}', json=payload, headers=admin_header)
         assert response.status_code == 200

--- a/tests/schemas/test_lease_schema.py
+++ b/tests/schemas/test_lease_schema.py
@@ -9,8 +9,8 @@ class TestLeaseValidations:
         tenant = create_tenant()
 
         valid_payload = {
-            'dateTimeStart': Time.today(),
-            'dateTimeEnd': Time.one_year_from_now(),
+            'dateTimeStart': Time.today_iso(),
+            'dateTimeEnd': Time.one_year_from_now_iso(),
             'tenantID': tenant.id,
             'propertyID': tenant.propertyID,
         }
@@ -26,7 +26,7 @@ class TestLeaseValidations:
 
     def test_dateTimeStart_validates_valid_format(self):
         validation_errors = LeaseSchema().validate(
-            {'dateTimeStart': Time.today()}
+            {'dateTimeStart': Time.today_iso()}
         )
 
         assert 'dateTimeStart' not in validation_errors
@@ -45,7 +45,7 @@ class TestLeaseValidations:
 
     def test_dateTimeEnd_validates_valid_date_format(self):
         validation_errors = LeaseSchema().validate(
-            {'dateTimeEnd': Time.today()}
+            {'dateTimeEnd': Time.one_year_from_now_iso()}
         )
 
         assert 'dateTimeEnd' not in validation_errors

--- a/tests/serializers/lease/test_lease_serializer.py
+++ b/tests/serializers/lease/test_lease_serializer.py
@@ -12,8 +12,8 @@ class TestLeaseSerializer:
 
         assert LeaseSerializer.serialize(lease) == {
                 'id': lease.id,
-                'dateTimeStart': Time.format_date(lease.dateTimeStart),
-                'dateTimeEnd': Time.format_date(lease.dateTimeEnd),
+                'dateTimeStart': Time.to_iso(lease.dateTimeStart),
+                'dateTimeEnd': Time.to_iso(lease.dateTimeEnd),
                 'occupants': lease.occupants,
                 'created_at': Time.format_date(lease.created_at),
                 'updated_at': Time.format_date(lease.updated_at),

--- a/utils/time.py
+++ b/utils/time.py
@@ -2,12 +2,17 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 time_format = "%m/%d/%Y %H:%M:%S"
+iso_format = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 class Time:
     @staticmethod
     def format_date(date):
         return date.strftime(time_format) if date else None
+
+    @staticmethod
+    def to_iso(date):
+        return date.strftime(iso_format)
 
     @staticmethod
     def format_date_by_year(date):
@@ -19,20 +24,28 @@ class Time:
 
     @staticmethod
     def today_iso():
-        return datetime.isoformat(datetime.today())
+        return Time.to_iso(datetime.today())
 
     @staticmethod
     def one_year_from_now():
-        return Time.format_date(datetime.today() + relativedelta(years=1))
+        return Time.format_date(Time._one_year())
 
     @staticmethod
     def one_year_from_now_iso():
-        return datetime.isoformat(datetime.today() + relativedelta(years=1))
+        return Time.to_iso(Time._one_year())
 
     @staticmethod
     def yesterday():
-        return Time.format_date(datetime.today() - relativedelta(days=1))
+        return Time.format_date(Time._yesterday())
 
     @staticmethod
     def yesterday_iso():
-        return datetime.isoformat(datetime.today() - relativedelta(days=1))
+        return Time.to_iso(Time._yesterday())
+
+    @staticmethod
+    def _yesterday():
+        return datetime.today() - relativedelta(days=1)
+
+    @staticmethod
+    def _one_year():
+        return datetime.today() + relativedelta(years=1)


### PR DESCRIPTION
No issue that I know of. This issue was reported by @DaveTrost on slack.

The lease was expecting time formats for the lease start and end date in the standard specified by Pythons iso8601 format although the javascript frontend is sending a simplified extended iso 8601 format. We had agreed upon the simplified extended  iso format so the backend is being changed to support that.