### PR TITLE
Remove init method on tenant model

### DIFF
--- a/data/seedData.py
+++ b/data/seedData.py
@@ -11,7 +11,7 @@ from models.emergency_contact import EmergencyContactModel
 from models.contact_number import ContactNumberModel
 from models.lease import LeaseModel
 from utils.time import time_format
-from schemas import PropertySchema
+from schemas import PropertySchema, TenantSchema
 
 
 def seedData():
@@ -158,24 +158,35 @@ def seedData():
     )
 
 
-    tenant_renty_mcrenter = TenantModel(firstName="Renty",
-                                        lastName="McRenter",
-                                        phone="800-RENT-ALOT",
-                                        staffIDs=[user_1.id, user_2.id]
-                                        )
-    tenant_renty_mcrenter.save_to_db()
-    tenant_soho_muless = TenantModel(firstName="Soho",
-                                     lastName="Muless",
-                                     phone="123-123-0000",
-                                     staffIDs=[]
-                                     )
-    tenant_soho_muless.save_to_db()
-    tenant_starvin_artist = TenantModel(firstName="Starvin",
-                                        lastName="Artist",
-                                        phone="123-123-1111",
-                                        staffIDs=[]
-                                        )
-    tenant_starvin_artist.save_to_db()
+    tenant_renty_mcrenter = TenantModel.create(
+        schema=TenantSchema,
+        payload={
+            'firstName': "Renty",
+            'lastName': "McRenter",
+            'phone': "800-RENT-ALOT",
+            'staffIDs': [user_janice_joinstaff.id, user_hector_chen.id]
+        }
+    )
+
+    tenant_soho_muless = TenantModel.create(
+        schema=TenantSchema,
+        payload={
+            'firstName': "Soho",
+            'lastName': "Muless",
+            'phone': "123-123-0000",
+            'staffIDs': []
+        }
+    )
+
+    tenant_starvin_artist = TenantModel.create(
+        schema=TenantSchema,
+        payload={
+            'firstName': "Starvin",
+            'lastName': "Artist",
+            'phone': "123-123-1111",
+            'staffIDs': []
+        }
+    )
 
     ticket_roof_on_fire = TicketModel(
         issue="The roof, the roof, the roof is on fire.",

--- a/models/tenant.py
+++ b/models/tenant.py
@@ -18,17 +18,6 @@ class TenantModel(BaseModel):
     leases = db.relationship('LeaseModel',
         backref='tenant', lazy=True, cascade="all, delete-orphan")
 
-    def __init__(self, firstName, lastName, phone, staffIDs):
-        self.firstName = firstName
-        self.lastName = lastName
-        self.phone = phone
-        self.staff = []
-        if not (staffIDs == None):
-            for id in staffIDs:
-                user = UserModel.find_by_id(id)
-                if user: self.staff.append(user)
-
-
     def json(self):
         return {
             'id': self.id,
@@ -40,7 +29,3 @@ class TenantModel(BaseModel):
             'created_at': Time.format_date(self.created_at),
             'updated_at': Time.format_date(self.updated_at)
         }
-
-    @classmethod
-    def find_by_first_and_last(cls, first, last):
-        return cls.query.filter_by(firstName=first, lastName=last).first()

--- a/resources/tenants.py
+++ b/resources/tenants.py
@@ -7,6 +7,7 @@ from models.tenant import TenantModel
 from models.user import UserModel
 from models.lease import LeaseModel
 from schemas.lease import LeaseSchema
+from schemas.tenant import TenantSchema
 from datetime import datetime
 from utils.time import Time
 from schemas.lease import LeaseSchema
@@ -21,12 +22,6 @@ from datetime import datetime
 # | DELETE | `v1/tenants/:id`     | Deletes a single tenant   |
 
 class Tenants(Resource):
-    parser = reqparse.RequestParser()
-    parser.add_argument('firstName',type=str,required=True,help="This field cannot be blank")
-    parser.add_argument('lastName',type=str,required=True,help="This field cannot be blank")
-    parser.add_argument('phone',type=str,required=True,help="This field cannot be blank")
-    parser.add_argument('staffIDs',action='append',required=False,help="This field can be provided at a later time")
-
     @admin_required
     def get(self, tenant_id=None):
         # GET /tenants
@@ -42,12 +37,7 @@ class Tenants(Resource):
 
     @admin_required
     def post(self):
-        data = Tenants.parser.parse_args()
-        if TenantModel.find_by_first_and_last(data["firstName"], data["lastName"]):
-            return { 'message': 'A tenant with this first and last name already exists'}, 401
-
-        tenantEntry = TenantModel(**data)
-        TenantModel.save_to_db(tenantEntry)
+        tenantEntry = TenantModel.create(schema=TenantSchema, payload=request.json)
 
         returnData = tenantEntry.json()
 
@@ -67,34 +57,7 @@ class Tenants(Resource):
 
     @admin_required
     def put(self, tenant_id):
-        parser_for_put = Tenants.parser.copy()
-        parser_for_put.replace_argument('firstName',required=False)
-        parser_for_put.replace_argument('lastName',required=False)
-        parser_for_put.replace_argument('phone',required=False)
-        data = parser_for_put.parse_args()
-
-        tenantEntry = TenantModel.find_by_id(tenant_id)
-        if not tenantEntry:
-            return {'message': 'Tenant not found'}, 404
-
-        #variable statements allow for only updated fields to be transmitted
-        if(data.firstName):
-            tenantEntry.firstName = data.firstName
-        if(data.lastName):
-            tenantEntry.lastName = data.lastName
-        if(data.phone):
-            tenantEntry.phone = data.phone
-        if(data.staffIDs and len(data.staffIDs)):
-            tenantEntry.staff[:] = []
-            for id in data.staffIDs:
-                user = UserModel.find_by_id(id)
-                if user: tenantEntry.staff.append(user)
-
-
-        tenantEntry.save_to_db()
-
-        return tenantEntry.json()
-
+        return TenantModel.update(schema=TenantSchema, payload=request.json, id=tenant_id).json()
 
     @admin_required
     def delete(self, tenant_id):

--- a/resources/tenants.py
+++ b/resources/tenants.py
@@ -1,17 +1,10 @@
-import json
-from flask_restful import Resource, reqparse
+from flask_restful import Resource
 from flask import request
 from utils.authorizations import admin_required
-from db import db
 from models.tenant import TenantModel
-from models.user import UserModel
 from models.lease import LeaseModel
 from schemas.lease import LeaseSchema
 from schemas.tenant import TenantSchema
-from datetime import datetime
-from utils.time import Time
-from schemas.lease import LeaseSchema
-from datetime import datetime
 
 # | method | route                | action                    |
 # | :----- | :------------------- | :------------------------ |

--- a/schemas/tenant.py
+++ b/schemas/tenant.py
@@ -35,7 +35,7 @@ class TenantSchema(ma.SQLAlchemyAutoSchema):
 
     @validates("staffIDs")
     def validate_staff_ids(self, value):
-        TenantModel.validate(StaffTenantSchema, {'staff': value}, partial=True)
+        StaffTenantSchema().load({'staff': value}, partial=True)
 
     @post_load
     def make_tenant_attributes(self, data, **kwargs):

--- a/schemas/tenant.py
+++ b/schemas/tenant.py
@@ -1,7 +1,9 @@
 from ma import ma
 from models.tenant import TenantModel
-from marshmallow import fields, validate
+from models.user import UserModel
+from marshmallow import fields, validate, validates, post_load
 from utils.time import time_format
+from schemas.staff_tenants import StaffTenantSchema
 
 
 class TenantSchema(ma.SQLAlchemyAutoSchema):
@@ -10,6 +12,8 @@ class TenantSchema(ma.SQLAlchemyAutoSchema):
 
     created_at = fields.DateTime(time_format)
     updated_at = fields.DateTime(time_format)
+
+    staffIDs = fields.List(fields.Integer(), required=False)
 
     firstName = fields.Str(
         required=True,
@@ -25,6 +29,17 @@ class TenantSchema(ma.SQLAlchemyAutoSchema):
 
     phone = fields.Str(
         required=True,
-        validate=validate.Length(min=10, max=20),
+        validate=validate.Length(min=10, max=30),
         error_messages={'required': 'Phone number is required.'},
     )
+
+    @validates("staffIDs")
+    def validate_staff_ids(self, value):
+        TenantModel.validate(StaffTenantSchema, {'staff': value}, partial=True)
+
+    @post_load
+    def make_tenant_attributes(self, data, **kwargs):
+        if 'staffIDs' in data:
+            data['staff'] = [ UserModel.find(staff) for staff in data['staffIDs'] ]
+            del(data['staffIDs'])
+        return data

--- a/tests/factory_fixtures/lease.py
+++ b/tests/factory_fixtures/lease.py
@@ -18,9 +18,8 @@ def lease_attributes(faker):
 @pytest.fixture
 def create_lease(faker, lease_attributes, create_property, create_tenant):
     def _create_lease(unitNum=faker.building_number()):
-        propertyID= create_property()
         tenant = create_tenant()
-        lease = LeaseModel(**lease_attributes(unitNum, tenant, propertyID))
+        lease = LeaseModel(**lease_attributes(unitNum, tenant, create_property()))
         lease.save_to_db()
         return lease
     yield _create_lease

--- a/tests/factory_fixtures/tenant.py
+++ b/tests/factory_fixtures/tenant.py
@@ -1,15 +1,22 @@
 import pytest
 from models.tenant import TenantModel
+from schemas.tenant import TenantSchema
 
 @pytest.fixture
-def create_tenant(faker):
+def tenant_attributes(faker, create_join_staff):
+    def _tenant_attributes(staff=[create_join_staff().id]):
+        return {
+            'firstName': faker.first_name(),
+            'lastName': faker.last_name(),
+            'phone': faker.phone_number(),
+            'staffIDs': staff
+        }
+
+    yield _tenant_attributes
+
+@pytest.fixture
+def create_tenant(tenant_attributes):
     def _create_tenant():
-        tenant = TenantModel(
-                firstName=faker.first_name(),
-                lastName=faker.last_name(),
-                phone=faker.phone_number(),
-                staffIDs=[]
-            )
-        tenant.save_to_db()
-        return tenant
+        return TenantModel.create(schema=TenantSchema, payload=tenant_attributes(staff=[]))
+
     yield _create_tenant

--- a/tests/schemas/test_tenant_schema.py
+++ b/tests/schemas/test_tenant_schema.py
@@ -1,4 +1,6 @@
+import pytest
 from datetime import datetime
+from models.tenant import TenantModel
 from schemas import TenantSchema
 from utils.time import Time
 
@@ -73,6 +75,11 @@ class TestTenantValidations:
 
         assert 'updated_at' in validation_errors
 
+    def test_staffIDs_are_validated(self, empty_test_db, create_property_manager):
+        pm = create_property_manager()
+        validation_error = TenantSchema().validate({"staffIDs": [pm.id]})
+
+        assert "staffIDs" in validation_error
 
 @pytest.mark.usefixtures('empty_test_db')
 class TestPostLoadDeserialization:

--- a/tests/schemas/test_tenant_schema.py
+++ b/tests/schemas/test_tenant_schema.py
@@ -50,12 +50,12 @@ class TestTenantValidations:
 
         assert 'lastName' in validation_errors
 
-    def test_phone_min_10(self):
+    def test_min_length_phone_number_validation(self):
         validation_errors = TenantSchema().validate({'phone': '1234'})
 
         assert 'phone' in validation_errors
 
-    def test_phone_max_20(self):
+    def test_max_length_phone_number_validation(self):
         long_phone_number = '8' * 41
         validation_errors = TenantSchema().validate({'phone': long_phone_number})
 

--- a/tests/schemas/test_tenant_schema.py
+++ b/tests/schemas/test_tenant_schema.py
@@ -54,7 +54,7 @@ class TestTenantValidations:
         assert 'phone' in validation_errors
 
     def test_phone_max_20(self):
-        long_phone_number = '8' * 21
+        long_phone_number = '8' * 41
         validation_errors = TenantSchema().validate({'phone': long_phone_number})
 
         assert 'phone' in validation_errors

--- a/tests/schemas/test_tenant_schema.py
+++ b/tests/schemas/test_tenant_schema.py
@@ -72,3 +72,17 @@ class TestTenantValidations:
         )
 
         assert 'updated_at' in validation_errors
+
+
+@pytest.mark.usefixtures('empty_test_db')
+class TestPostLoadDeserialization:
+    def test_tenant_creation(self, tenant_attributes, create_property, create_join_staff):
+        staff_1 = create_join_staff()
+        staff_2 = create_join_staff()
+
+        tenant_attrs = tenant_attributes(staff=[staff_1.id, staff_2.id])
+
+        tenant = TenantModel.create(schema=TenantSchema, payload=tenant_attrs)
+
+        assert tenant
+        assert tenant.staff == [staff_1, staff_2]

--- a/tests/unit/test_tenant.py
+++ b/tests/unit/test_tenant.py
@@ -1,15 +1,32 @@
+import pytest
+from tests.unit.base_interface_test import BaseInterfaceTest
 from models.tenant import TenantModel
-
-firstName = "Renty"
-lastName = "McRenter"
-phone = "800-RENT-ALOT"
-propertyID = 1
-staffIDs = [1, 2]
+from schemas.tenant import TenantSchema
 
 
-def test_tenant(test_database):
-    newTenant = TenantModel(firstName=firstName, lastName=lastName,
-                            phone=phone, staffIDs=staffIDs)
-    assert newTenant.firstName == firstName
-    assert newTenant.lastName == lastName
-    assert newTenant.phone == phone
+
+class TestBaseTenantModel(BaseInterfaceTest):
+    def setup(self):
+        self.object = TenantModel()
+        self.custom_404_msg = 'Tenant not found'
+        self.schema = TenantSchema
+
+
+@pytest.mark.usefixtures('empty_test_db')
+class TestTenant:
+    def test_tenant_creation(self, tenant_attributes, create_property, create_join_staff):
+        staff_1 = create_join_staff()
+        staff_2 = create_join_staff()
+
+        tenant_attrs = tenant_attributes(staff=[staff_1.id, staff_2.id])
+
+        tenant = TenantModel.create(schema=TenantSchema, payload=tenant_attrs)
+
+        assert tenant
+        assert tenant.staff == [staff_1, staff_2]
+
+
+@pytest.mark.usefixtures('empty_test_db')
+class TestTenantFactory:
+    def test_create_tenant(self, create_tenant):
+        assert create_tenant()

--- a/tests/unit/test_tenant.py
+++ b/tests/unit/test_tenant.py
@@ -13,20 +13,6 @@ class TestBaseTenantModel(BaseInterfaceTest):
 
 
 @pytest.mark.usefixtures('empty_test_db')
-class TestTenant:
-    def test_tenant_creation(self, tenant_attributes, create_property, create_join_staff):
-        staff_1 = create_join_staff()
-        staff_2 = create_join_staff()
-
-        tenant_attrs = tenant_attributes(staff=[staff_1.id, staff_2.id])
-
-        tenant = TenantModel.create(schema=TenantSchema, payload=tenant_attrs)
-
-        assert tenant
-        assert tenant.staff == [staff_1, staff_2]
-
-
-@pytest.mark.usefixtures('empty_test_db')
 class TestTenantFactory:
     def test_create_tenant(self, create_tenant):
         assert create_tenant()


### PR DESCRIPTION
### What issue is this solving?
Partially resolves issue codeforpdx/dwellingly-app/issues/398

Sorry, did this in one commit. I was streaming part of this work and I have a hard time talking, thinking, and typing at the same time. It is pretty similar to PR #181 

Removed validation for tenants with the same first and last name. If this is needed we can add it to the schema, although there are many people with the same first and last name so I would advise against this unless it is specifically requested from the client.

Increased length validation on phone_number as the faker library can and will produce phone_numbers greater than 20 digits. For example `+1-604-876-4759x38242` - and some international phone numbers can have even more digits. It's probably best to be lenient with our validations unless specifically required, especially since multi-tenancy can be a thing in the future.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? Yes, i think db needs to be re-created
Any new dependencies to install? No
Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
