### PR TITLE
Advanced setup info/documentation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,4 @@
 max-line-length = 80
 select = C,E,F,W,B,B950
 ignore = E203,E501,W503
+exclude = __init__.py

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate code style to Black
+82a8f7c9aef1cf07f4d6b956d794897de2c841ec

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,7 @@ NOTE: Database is SQLite3 via SQLAlchemy
       - As a web page: `pipenv run python view_coverage.py`
       - In the console: `pipenv run view_coverage`
     - Tests can be run automatically after each file save using [pytest-watch](https://pypi.org/project/pytest-watch/). Visit the documentation to learn how to run it for your system. See [PR #72](https://github.com/codeforpdx/dwellinglybackend/pull/72) for a preview of what it can do.
+9. (OPTIONAL) Set up your workflow using the [Advanced Setup documentation](./advanced_setup.md)
 
 Queries can be made with the Postman Collection link ( https://www.getpostman.com/collections/a86a292798c7895425e2 )
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/0078de8f58d4ea0b78eb)
@@ -167,6 +168,9 @@ How to contribute to this project.
     - The pre-commit hook will check your code every time you try to commit. If your code needs re-formatting, that will happen automatically. If you have non-formatting errors in your code, these will be printed to the terminal with the error, filename and line number. You will need to resolve these yourself.
     - After your code has been reformatted and/or you have resolved other errors, you will need to add and commit those files again (because they have been modified).
     - Successful commits can then be pushed to your remote branch like normal.
+    - NOTE: If you did not set up pre-commit as described in Step 4 of [Installation](#Installation), our CI will still perform these checks when you make a PR into `development`. If the build fails, you will be asked to push the appropriate changes to your branch before it can be merged.
+
+(For more information on the pre-commit hook, Flake8 and the Black formatter, see the [Advanced Setup documentation](./advanced_setup.md))
 
 #### Updating development branch
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Dwellingly App Backend
 [![Build Status](https://travis-ci.com/codeforpdx/dwellinglybackend.svg?branch=development)](https://travis-ci.com/codeforpdx/dwellinglybackend)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 _Looking for the [Dwellingly App front end?](https://github.com/codeforpdx/dwellingly-app)_
 

--- a/advanced_setup.md
+++ b/advanced_setup.md
@@ -5,15 +5,17 @@ Any additional setup instructions referenced here are completely optional, but a
 
 ## Table of Contents
 
-- [Introduction](#Introduction)
-  - [This sounds painful, is it even worth it?](#This-sounds-painful-is-it-even-worth-it)
-- [Flake8](#Flake8)
-  - [Flake8 on Command Line](#Flake8-Command-Line-Usage)
-  - [Flake8 in your Editor](#Use-Flake8-in-Your-Editor)
-- [Black](#Black)
-  - [Black on Command Line](#Black-Command-Line-Usage)
-  - [Black in your Editor](#Use-Black-in-Your-Editor)
-- [Git Blame](#Git-Blame)
+- [Introduction](#introduction)
+  - [This sounds painful, is it even worth it?](#this-sounds-painful-is-it-even-worth-it)
+- [Flake8](#flake8)
+  - [Flake8 on Command Line](#flake8-command-line-usage)
+  - [Flake8 in your Editor](#use-flake8-in-your-editor)
+- [Black](#black)
+  - [Black on Command Line](#black-command-line-usage)
+  - [Black in your Editor](#use-black-in-your-editor)
+- [Git Blame](#git-blame)
+  - [Git Blame on Command Line](#git-blame-command-line-usage)
+  - [Git Blame in your Editor](#git-blame-in-your-editor)
 
 ## Introduction
 

--- a/advanced_setup.md
+++ b/advanced_setup.md
@@ -1,0 +1,166 @@
+# Advanced Setup (optional)
+
+_This document applies to the newer project features implemented by [PR #185](https://github.com/codeforpdx/dwellinglybackend/pull/185) as part of the push to enforce uniform code standards for the Dwellingly backend.
+Any additional setup instructions referenced here are completely optional, but are worth the extra step if you feel comfortable doing so._
+
+## Table of Contents
+
+- [Introduction](#Introduction)
+  - [This sounds painful, is it even worth it?](#This-sounds-painful-is-it-even-worth-it)
+- [Flake8](#Flake8)
+  - [Flake8 on Command Line](#Flake8-Command-Line-Usage)
+  - [Flake8 in your Editor](#Use-Flake8-in-Your-Editor)
+- [Black](#Black)
+  - [Black on Command Line](#Black-Command-Line-Usage)
+  - [Black in your Editor](#Use-Black-in-Your-Editor)
+- [Git Blame](#Git-Blame)
+
+## Introduction
+
+We recently introduced strict linting and formatting requirements for all code being added to the Dwellingly backend repo. This is accomplished through a combination of:
+
+- [Flake8](https://github.com/PyCQA/flake8) (supplemented by [Flake8-bugbear](https://github.com/PyCQA/flake8-bugbear)) for linting
+- [Black](https://github.com/psf/black) for formatting Python files, and
+- [Pre-commit](https://pre-commit.com/) to run these checks as well as some whitespace checks on every `git commit`.
+
+As the name suggests, Pre-commit will do the following _before_ your commit is processed:
+
+- Check for the required newline at the end of every file (will auto-fix)
+- Check for trailing whitespace on all lines of every file (will auto-fix)
+- Check Python files for compliance with Black formatting (will auto-fix if possible)
+- Check Python files for [PEP8](https://www.python.org/dev/peps/pep-0008/) compliance via Flake8 and Flake8-bugbear (will **not** auto-fix)
+
+If any of these checks don't pass, your commit will be aborted &mdash; _even if your files were auto-fixed by the pre-commit hook_.
+
+Occasionally, Black will not be able to auto-format some of your code during the pre-commit hook (e.g., if you have a really long string or comment).  In that case, you will need to make that fix manually.  All Flake8 errors will need to be resolved manually as well.
+
+Once all changes have been made (by you or by automation), you must `git add` and `git commit` again. If everything was properly resolved, your commit will be successful.
+
+### This sounds painful, is it even worth it?
+
+Yes, absolutely.
+
+The pre-commit hook (and the backup pre-commit hook in our CI) will ensure that no matter which contributor wrote the code, all Python in the repo will be formatted the same way. Some advantages include:
+
+- Faster review:
+  - All the code will look similar, with no personal quirks or strange styling hold-overs from other languages. This makes it faster to read, comprehend and give feedback on newly added code.
+  - Git diffs will be smaller and clearer because Black tends to make the code more vertical. Vertical code means there won't be a gigantically long diff when, e.g., one item in a list gets changed.
+- Faster time to merge:
+  - Gone are the days of being asked to add a newline or remove an import before your PRs can be merged. The pre-commit takes care of this for you before the reviewer ever sees your code.
+- Closer to production ready:
+  - Extraneous code, such as unused imports or unused variables, will always trigger a Flake8 error and cannot be committed. Cleaner code now means less work in the future when we switch from development to production.
+
+It is also important to recognize that you don't have to go blindly into your commit, hoping to pass the tests. Pre-commit is the enforcer, but the real power behind linters and formatters comes through using them as you write your code, not only at the end.
+
+The following sections contain instructions on using Flake8 and Black on the command line as well and links on how to set these up for automatic use with a variety of IDEs and code editors. [Git Blame](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt) is also mentioned, as it is a useful tool when working on teams and requires some special set-up since we migrated to Black late in the project.
+
+---
+
+## Flake8
+
+Flake8 lints your Python files, letting you know if you have any problems with your code or if your code does not meet PEP8 standards.  If it detects problems with your code, you will have to fix them yourself.  You can lint your code periodically from the command line, or set up your editor to do it for you by following the instructions below.
+
+### Flake8 Command Line Usage
+
+Run the following command from the `dwellinglybackend` directory to lint all Python files in the repo:
+
+```console
+pipenv run flake8
+```
+
+You can also narrow the scope of your linting by passing in the path for the directory or file you want to lint:
+
+```console
+pipenv run flake8 {path_to_dir_or_file}
+```
+
+If you need more advanced options, check out the [Flake8 documentation](https://flake8.pycqa.org/en/latest/user/invocation.html).
+
+### Use Flake8 in Your Editor
+
+For even more instantaneous linting, you can also set up Flake8 with most IDEs and code editors.
+
+Every editor is configured differently, so if your editor of choice isn't listed, a quick Google search may be needed. Please add documentation links to this list if you successfully integrate Flake8 with an editor not listed here!
+
+- VS Code:
+  - Add the settings from [settings.json.example](./settings.json.example) to your `settings.json` file; or
+  - Follow the [official documentation](https://code.visualstudio.com/docs/python/linting)
+- PyCharm:
+  - Follow the instructions in this [Real Python article](https://code.visualstudio.com/docs/python/linting) (under the section _Using Plugins and External Tools in PyCharm_)
+- Atom:
+  - Go to Settings -> Install, search for the `linter-flake8` package, then click Install
+- Vim:
+  - Follow the instructions in [this gist](https://gist.github.com/za/983db825aee2dc352d5341da357cbfb4)
+
+
+## _Black_
+
+Black is a code formatter that formats Python files according to very opinionated PEP8-compliant styling rules. When Black is run, it will check your file(s) and if it decides changes are needed, it will re-format your code to the best of its abilities.  This will never change the substance of your code, only the styling. Occasionally, Black will not be able to auto-format part of your code (such as extra long strings or comments) and you will need to make those changes manually.
+
+### _Black_ Command Line Usage
+
+Run the following command from the `dwellinglybackend` directory to format all Python files in the repo using Black:
+
+```console
+pipenv run black .
+```
+
+To format only a specific file or directory, you simply specify the path, as you would with Flake8:
+
+```console
+pipenv run black {source_file_or_directory}
+```
+
+For advanced command line options, see the [Black documentation](https://black.readthedocs.io/en/stable/installation_and_usage.html#usage).
+
+### Use _Black_ in Your Editor
+
+One of the best features of code formatters is that you can set them up to _format on save_ with your editor. Once set up, every time you save your file, Black will auto-format the code you wrote. This is a no-brainer way to fix your code before commit time.
+
+- Most Editors:
+  - The Black documentation has a fairly extensive section on [editor integration](https://black.readthedocs.io/en/stable/editor_integration.html). Follow those instructions, and if your editor is not listed, consider opening up an issue on their [GitHub page](https://github.com/psf/black).
+
+## Git Blame
+
+Git blame is a built-in feature of Git that allows you to see the most recent commit and author that changed any given line of code in a file. Git blame can be incredibly useful on team projects because if you find a bug or don't understand a certain section of the code, you can reach out to the original author or read the commit messages where the code was added.
+
+### Cleansing the Git Blame
+
+One unfortunate side effect of migrating to Black code style late in a project's lifecycle is that the initial re-formatting of the files will pollute the git blame.  Essentially, most lines of most files will blame the author of the commit that did the re-formatting rather than the last person who _really_ changed the code.
+
+If you want to use Git Blame for this project, you should tell Git to ignore the re-formatting commit by running the following command from inside the `dwellinglybackend` directory:
+
+```console
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+After this command is run, lines modified by backend PR #185 will be blamed on the previous revision that modified those lines.
+
+### Git Blame Command Line Usage
+
+To use Git blame on the command line, it's as simple as running this command:
+
+```console
+git blame {path_to_file}
+```
+
+You will see the blame annotations in your terminal and you can navigate through them using the up and down arrows.  To exit the blame, press `q`.  If you are familiar with using the `git log` command, this will be familiar to you.
+
+For advanced command line options, see the [git documentation](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt).
+
+### Git Blame in Your Editor
+
+Where Git blame really shines is in the interactive extensions for various code editors &mdash; VS Code in particular.  These extensions have awesome features that range from color-coded revisions to in-line annotations and GitHub integration. Below are examples for some editors we use.
+
+Every editor has different extensions, so if your editor of choice isn't listed, a quick Google search may be needed. Please add documentation links to this list if you find an awesome Git blame extension for an editor not listed here!
+
+- VS Code:
+  - [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) - the gold standard of Git blame extensions.
+- PyCharm:
+  - PyCharm's built-in [VCS Annotations](https://www.jetbrains.com/help/pycharm/investigate-changes.html#annotate)
+- Atom:
+  - [Atom-inline-blame](https://github.com/gregorym/atom-inline-blame) and/or
+  - the [git-blame](https://github.com/alexcorre/git-blame/tree/v1.8.0) package
+- Vim:
+  - [Fugitive.vim](https://github.com/tpope/vim-fugitive) and/or
+  - [Git-blame.vim](https://github.com/zivyangll/git-blame.vim)

--- a/settings.json.example
+++ b/settings.json.example
@@ -2,7 +2,8 @@
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": true,
+    "python.formatting.provider": "black",
     "python.testing.pytestEnabled": true,
     "python.testing.pytestArgs": [
         "tests"


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
No issue, this is primarily a documentation PR relating to the new styling/formatting system implemented by PR #185.

I added/updated some configuration files to make it easier for team members to use Flake8, Black and Git Blame in their editors or on the command line.

Documentation changes are:
- Add codestyle black badge to the README 😎 
- Add reference to the new advanced setup options in `CONTRIBUTING.md`
- Add note in `CONTRIBUTING` that mentions the CI will reject PRs that have not been linted and formatted by Flake8 and Black.
- Add new "advanced settings" file (for lack of a better name)
  - This file explains the how and why of pre-commit, black, flake8 and git blame and how to set them up on your editor or use them on the command line.

**I am primarily looking for feedback on the advanced settings documentation.**  View the rich diff [here](https://github.com/codeforpdx/dwellinglybackend/pull/188/commits/7baf7411f3765a33d5e5cbec8b35d3ab3b63018d?short_path=0aac14a#diff-0aac14a5afb07111433673dfb50d150d5c6b9a6f7bffa77c0984b5bc849fca94) for easier reading.

My goal in writing it was to both demystify what is happening with the new pre-commit hook and to help team members set up the best tools in their own workflow that will help minimize the number of commits that pre-commit will reject. 

Please comment and let me know if:
- this is helpful
- this is unnecessary
- anything should be changed or added
- anything else you can think of!



### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? NO
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
