### PR TITLE
Require contact numbers

### DIFF
--- a/models/contact_number.py
+++ b/models/contact_number.py
@@ -7,7 +7,7 @@ class ContactNumberModel(BaseModel):
     __tablename__ = "contact_numbers"
 
     id = db.Column(db.Integer, primary_key=True)
-    number = db.Column(db.String(20), nullable=False)
+    number = db.Column(db.String(30), nullable=False)
     numtype = db.Column(db.String(30))
     extension = db.Column(db.String(10))
     emergency_contact_id = db.Column(

--- a/schemas/emergency_contact.py
+++ b/schemas/emergency_contact.py
@@ -11,9 +11,16 @@ class EmergencyContactSchema(ma.SQLAlchemyAutoSchema):
     created_at = fields.DateTime(time_format)
     updated_at = fields.DateTime(time_format)
 
-    contact_numbers = fields.List(fields.Nested("ContactNumberSchema"))
+    contact_numbers = fields.List(fields.Nested("ContactNumberSchema"), required=True)
 
     @validates("name")
     def validate_name(self, value):
         if EmergencyContactModel.find_by_name(value):
             raise ValidationError(f"{value} is already an emergency contact")
+
+    @validates("contact_numbers")
+    def validate_contact_numbers(self, contact_numbers):
+        if len(contact_numbers) < 1:
+            raise ValidationError(
+                "Emergency contacts must have at least one contact number."
+            )

--- a/tests/factory_fixtures/emergency_contact.py
+++ b/tests/factory_fixtures/emergency_contact.py
@@ -4,6 +4,18 @@ from models.contact_number import ContactNumberModel
 
 
 @pytest.fixture
+def emergency_contact_attributes(faker, contact_number_attributes):
+    def _emergency_contact_attributes():
+        return {
+            "name": faker.name().upper(),
+            "description": faker.sentence(nb_words=5),
+            "contact_numbers": [contact_number_attributes],
+        }
+
+    yield _emergency_contact_attributes()
+
+
+@pytest.fixture
 def create_emergency_contact(faker, contact_number_attributes):
     def _create_emergency_contact():
         emergency_contact = EmergencyContactModel(

--- a/tests/integration/test_emergency_contacts.py
+++ b/tests/integration/test_emergency_contacts.py
@@ -96,12 +96,6 @@ def test_emergency_contacts_POST(client, auth_headers):
     assert is_valid(
         response, 400
     )  # BAD REQUEST - {'name': 'This Field Cannot Be Blank.'}
-    assert response.json == {
-        "message": {
-            "name": ["Missing data for required field."],
-            "contact_numbers": ["Missing data for required field."],
-        }
-    }
 
 
 def test_emergency_contacts_PUT(client, auth_headers):

--- a/tests/integration/test_emergency_contacts.py
+++ b/tests/integration/test_emergency_contacts.py
@@ -96,7 +96,12 @@ def test_emergency_contacts_POST(client, auth_headers):
     assert is_valid(
         response, 400
     )  # BAD REQUEST - {'name': 'This Field Cannot Be Blank.'}
-    assert response.json == {"message": {"name": ["Missing data for required field."]}}
+    assert response.json == {
+        "message": {
+            "name": ["Missing data for required field."],
+            "contact_numbers": ["Missing data for required field."],
+        }
+    }
 
 
 def test_emergency_contacts_PUT(client, auth_headers):

--- a/tests/schemas/test_contact_number_schema.py
+++ b/tests/schemas/test_contact_number_schema.py
@@ -7,3 +7,15 @@ class TestContactNumberValidation:
         no_validation_errors = {}
 
         assert no_validation_errors == ContactNumberSchema().validate(valid_payload)
+
+    def test_empty_payload(self, empty_test_db):
+        empty_payload = {}
+        validation_errors = ContactNumberSchema().validate(empty_payload)
+
+        assert "number" in validation_errors
+
+    def test_invalid_payload(self, empty_test_db):
+        invalid_payload = {"number": None}
+        validation_errors = ContactNumberSchema().validate(invalid_payload)
+
+        assert "number" in validation_errors

--- a/tests/schemas/test_contact_number_schema.py
+++ b/tests/schemas/test_contact_number_schema.py
@@ -1,21 +1,39 @@
+import pytest
 from schemas.contact_number import ContactNumberSchema
 
 
+@pytest.mark.usefixture("empty_test_db")
 class TestContactNumberValidation:
-    def test_valid_payload(self, empty_test_db):
+    def test_valid_payload(self):
         valid_payload = {"number": "503-503-503"}
         no_validation_errors = {}
 
         assert no_validation_errors == ContactNumberSchema().validate(valid_payload)
 
-    def test_empty_payload(self, empty_test_db):
+    def test_empty_payload(self):
         empty_payload = {}
         validation_errors = ContactNumberSchema().validate(empty_payload)
 
         assert "number" in validation_errors
 
-    def test_invalid_payload(self, empty_test_db):
+    def test_invalid_payload(self):
         invalid_payload = {"number": None}
+        validation_errors = ContactNumberSchema().validate(invalid_payload)
+
+        assert "number" in validation_errors
+
+    def test_contact_num_too_long(self):
+        invalid_payload = {
+            "number": "123-456-7890123456789",
+        }
+        validation_errors = ContactNumberSchema().validate(invalid_payload)
+
+        assert "number" in validation_errors
+
+    def test_contact_num_not_string(self):
+        invalid_payload = {
+            "number": 503 - 123 - 4567,
+        }
         validation_errors = ContactNumberSchema().validate(invalid_payload)
 
         assert "number" in validation_errors

--- a/tests/schemas/test_contact_number_schema.py
+++ b/tests/schemas/test_contact_number_schema.py
@@ -1,38 +1,28 @@
-import pytest
 from schemas.contact_number import ContactNumberSchema
 
 
-@pytest.mark.usefixture("empty_test_db")
 class TestContactNumberValidation:
-    def test_valid_payload(self):
-        valid_payload = {"number": "503-503-5031"}
+    def test_valid_payload(self, contact_number_attributes):
+        valid_payload = contact_number_attributes
         no_validation_errors = {}
 
         assert no_validation_errors == ContactNumberSchema().validate(valid_payload)
 
-    def test_empty_payload(self):
+    def test_empty_payload_is_invalid(self):
         empty_payload = {}
         validation_errors = ContactNumberSchema().validate(empty_payload)
 
         assert "number" in validation_errors
 
-    def test_invalid_payload(self):
+    def test_number_cannot_be_null(self):
         invalid_payload = {"number": None}
         validation_errors = ContactNumberSchema().validate(invalid_payload)
 
         assert "number" in validation_errors
 
-    def test_contact_num_too_long(self):
+    def test_number_cannot_exceed_max_length(self):
         invalid_payload = {
-            "number": "123-456-7890123456789",
-        }
-        validation_errors = ContactNumberSchema().validate(invalid_payload)
-
-        assert "number" in validation_errors
-
-    def test_contact_num_not_string(self):
-        invalid_payload = {
-            "number": 503 - 123 - 4567,
+            "number": "8" * 50,
         }
         validation_errors = ContactNumberSchema().validate(invalid_payload)
 

--- a/tests/schemas/test_contact_number_schema.py
+++ b/tests/schemas/test_contact_number_schema.py
@@ -5,7 +5,7 @@ from schemas.contact_number import ContactNumberSchema
 @pytest.mark.usefixture("empty_test_db")
 class TestContactNumberValidation:
     def test_valid_payload(self):
-        valid_payload = {"number": "503-503-503"}
+        valid_payload = {"number": "503-503-5031"}
         no_validation_errors = {}
 
         assert no_validation_errors == ContactNumberSchema().validate(valid_payload)

--- a/tests/schemas/test_emergency_contact_schema.py
+++ b/tests/schemas/test_emergency_contact_schema.py
@@ -4,17 +4,13 @@ from schemas.emergency_contact import EmergencyContactSchema
 
 @pytest.mark.usefixtures("empty_test_db")
 class TestEmergencyContactValidations:
-    def test_valid_payload(self):
-        valid_payload = {
-            "name": "emergency contact name",
-            "contact_numbers": [{"number": "503-456-7890"}],
-        }
-
+    def test_valid_payload(self, emergency_contact_attributes):
+        valid_payload = emergency_contact_attributes
         no_validation_errors = {}
 
         assert no_validation_errors == EmergencyContactSchema().validate(valid_payload)
 
-    def test_validate_empty_contact_number(self):
+    def test_contact_numbers_cannot_be_empty(self):
         invalid_payload = {
             "name": "emergency contact name",
             "contact_numbers": [],
@@ -23,7 +19,7 @@ class TestEmergencyContactValidations:
 
         assert "contact_numbers" in validation_errors
 
-    def test_validate_missing_contact_numbers(self):
+    def test_contact_numbers_required(self):
         invalid_payload = {
             "name": "emergency contact name",
         }
@@ -31,14 +27,12 @@ class TestEmergencyContactValidations:
 
         assert "contact_numbers" in validation_errors
 
-    def test_validate_multiple_contact_numbers(self):
-        valid_payload = {
-            "name": "emergency contact name",
-            "contact_numbers": [
-                {"number": "503-291-9111", "numtype": "Call"},
-                {"number": "503-555-3321", "numtype": "Text"},
-            ],
-        }
+    def test_multiple_contact_numbers_is_valid(
+        self, emergency_contact_attributes, contact_number_attributes
+    ):
+        valid_payload = emergency_contact_attributes
+        valid_payload["contact_numbers"].append(contact_number_attributes)
+
         no_validation_errors = {}
 
         assert no_validation_errors == EmergencyContactSchema().validate(valid_payload)

--- a/tests/schemas/test_emergency_contact_schema.py
+++ b/tests/schemas/test_emergency_contact_schema.py
@@ -1,8 +1,10 @@
+import pytest
 from schemas.emergency_contact import EmergencyContactSchema
 
 
+@pytest.mark.usefixtures("empty_test_db")
 class TestEmergencyContactValidations:
-    def test_valid_payload(self, empty_test_db):
+    def test_valid_payload(self):
         valid_payload = {
             "name": "emergency contact name",
             "contact_numbers": [{"number": "503-456-7890"}],
@@ -12,13 +14,24 @@ class TestEmergencyContactValidations:
 
         assert no_validation_errors == EmergencyContactSchema().validate(valid_payload)
 
-    def test_validate_empty_contact_number(self, empty_test_db):
-        invalid_payload = {"name": "emergency contact name", "contact_numbers": [{}]}
+    def test_validate_empty_contact_number(self):
+        invalid_payload = {
+            "name": "emergency contact name",
+            "contact_numbers": [],
+        }
         validation_errors = EmergencyContactSchema().validate(invalid_payload)
 
         assert "contact_numbers" in validation_errors
 
-    def test_validate_multiple_contact_numbers(self, empty_test_db):
+    def test_validate_missing_contact_numbers(self):
+        invalid_payload = {
+            "name": "emergency contact name",
+        }
+        validation_errors = EmergencyContactSchema().validate(invalid_payload)
+
+        assert "contact_numbers" in validation_errors
+
+    def test_validate_multiple_contact_numbers(self):
         valid_payload = {
             "name": "emergency contact name",
             "contact_numbers": [
@@ -30,7 +43,7 @@ class TestEmergencyContactValidations:
 
         assert no_validation_errors == EmergencyContactSchema().validate(valid_payload)
 
-    def test_contact_num_too_long(self, empty_test_db):
+    def test_contact_num_too_long(self):
         invalid_payload = {
             "name": "emergency contact name",
             "contact_numbers": [{"number": "123-456-7890123456789"}],
@@ -39,7 +52,7 @@ class TestEmergencyContactValidations:
 
         assert "contact_numbers" in validation_errors
 
-    def test_contact_num_not_string(self, empty_test_db):
+    def test_contact_num_not_string(self):
         invalid_payload = {
             "name": "emergency contact name",
             "contact_numbers": [{"number": 503 - 123 - 4567}],

--- a/tests/schemas/test_emergency_contact_schema.py
+++ b/tests/schemas/test_emergency_contact_schema.py
@@ -42,21 +42,3 @@ class TestEmergencyContactValidations:
         no_validation_errors = {}
 
         assert no_validation_errors == EmergencyContactSchema().validate(valid_payload)
-
-    def test_contact_num_too_long(self):
-        invalid_payload = {
-            "name": "emergency contact name",
-            "contact_numbers": [{"number": "123-456-7890123456789"}],
-        }
-        validation_errors = EmergencyContactSchema().validate(invalid_payload)
-
-        assert "contact_numbers" in validation_errors
-
-    def test_contact_num_not_string(self):
-        invalid_payload = {
-            "name": "emergency contact name",
-            "contact_numbers": [{"number": 503 - 123 - 4567}],
-        }
-        validation_errors = EmergencyContactSchema().validate(invalid_payload)
-
-        assert "contact_numbers" in validation_errors


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/497

Summary of changes:

- Updated `EmergencyContactSchema` to require `contact_numbers` field and validate whether `contact_numbers` had a length of less than 1.
- Updated and moved around tests as needed.

Note: I didn't add much to the `integration/test_emergency_contacts` file because the schema should be taking care of all that validation and we are already cover that in the schema tests.  I believe once this refactor is complete we will only need to test the happy path for the resource, as other tests will likely be redundant.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? NO
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
