### PR TITLE
Allow property to be updated when the name has not changed

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -36,9 +36,9 @@ class BaseModel(db.Model):
         return obj
 
     @classmethod
-    def update(cls, schema, id, payload):
+    def update(cls, schema, id, payload, context=None):
         obj = cls.find(id)
-        attrs = cls.validate(schema, payload, partial=True)
+        attrs = cls.validate(schema, payload, context=context, partial=True)
 
         for k, v in attrs.items():
             setattr(obj, k, v)
@@ -48,9 +48,14 @@ class BaseModel(db.Model):
         return obj
 
     @staticmethod
-    def validate(schema, payload, partial=False):
+    def validate(schema, payload, context=None, partial=False):
         try:
-            return schema().load(payload, unknown=EXCLUDE, partial=partial)
+            if context:
+                return schema(context=context).load(
+                    payload, unknown=EXCLUDE, partial=partial
+                )
+            else:
+                return schema().load(payload, unknown=EXCLUDE, partial=partial)
         except ValidationError as err:
             abort(400, err.messages)
 

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -50,12 +50,9 @@ class BaseModel(db.Model):
     @staticmethod
     def validate(schema, payload, context=None, partial=False):
         try:
-            if context:
-                return schema(context=context).load(
-                    payload, unknown=EXCLUDE, partial=partial
-                )
-            else:
-                return schema().load(payload, unknown=EXCLUDE, partial=partial)
+            return schema(context=context).load(
+                payload, unknown=EXCLUDE, partial=partial
+            )
         except ValidationError as err:
             abort(400, err.messages)
 

--- a/resources/property.py
+++ b/resources/property.py
@@ -90,7 +90,7 @@ class Property(Resource):
     @admin_required
     def put(self, id):
         payload = request.json
-        context = {"request_type": "PUT", "name": payload["name"]}
+        context = {"name": payload["name"]}
 
         return PropertyModel.update(
             schema=PropertySchema, id=id, context=context, payload=payload

--- a/resources/property.py
+++ b/resources/property.py
@@ -3,7 +3,7 @@ from flask import request
 from utils.authorizations import admin_required
 from db import db
 from models.property import PropertyModel
-from schemas.property import PropertySchema, PropertyUpdateSchema
+from schemas.property import PropertySchema
 
 # | method | route                | action                     |
 # | :----- | :------------------- | :------------------------- |
@@ -90,8 +90,8 @@ class Property(Resource):
     @admin_required
     def put(self, id):
         payload = request.json
-        if "id" not in payload:
-            payload["id"] = id
+        context = {"request_type": "PUT", "name": payload["name"]}
+
         return PropertyModel.update(
-            schema=PropertyUpdateSchema, id=id, payload=payload
+            schema=PropertySchema, id=id, context=context, payload=payload
         ).json()

--- a/resources/property.py
+++ b/resources/property.py
@@ -3,7 +3,7 @@ from flask import request
 from utils.authorizations import admin_required
 from db import db
 from models.property import PropertyModel
-from schemas.property import PropertySchema
+from schemas.property import PropertySchema, PropertyUpdateSchema
 
 # | method | route                | action                     |
 # | :----- | :------------------- | :------------------------- |
@@ -89,6 +89,9 @@ class Property(Resource):
 
     @admin_required
     def put(self, id):
+        payload = request.json
+        if "id" not in payload:
+            payload["id"] = id
         return PropertyModel.update(
-            schema=PropertySchema, id=id, payload=request.json
+            schema=PropertyUpdateSchema, id=id, payload=payload
         ).json()

--- a/resources/property.py
+++ b/resources/property.py
@@ -89,8 +89,9 @@ class Property(Resource):
 
     @admin_required
     def put(self, id):
+        property = PropertyModel.find(id)
         payload = request.json
-        context = {"name": payload["name"]}
+        context = {"name": property.name}
 
         return PropertyModel.update(
             schema=PropertySchema, id=id, context=context, payload=payload

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,6 +1,6 @@
 from .lease import LeaseSchema
 from .tenant import TenantSchema
-from .property import PropertySchema, PropertyUpdateSchema
+from .property import PropertySchema
 from .property_assignment import PropertyAssignSchema
 from .user import *
 from .staff_tenants import StaffTenantSchema

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,6 +1,6 @@
 from .lease import LeaseSchema
 from .tenant import TenantSchema
-from .property import PropertySchema
+from .property import PropertySchema, PropertyUpdateSchema
 from .property_assignment import PropertyAssignSchema
 from .user import *
 from .staff_tenants import StaffTenantSchema

--- a/schemas/property.py
+++ b/schemas/property.py
@@ -2,7 +2,7 @@ from ma import ma
 from models.property import PropertyModel
 from models.user import UserModel
 from schemas.property_assignment import PropertyAssignSchema
-from marshmallow import fields, validates, ValidationError, post_load
+from marshmallow import fields, validates, ValidationError, post_load, pre_load
 from utils.time import time_format
 
 
@@ -36,4 +36,14 @@ class PropertySchema(ma.SQLAlchemyAutoSchema):
                 UserModel.find(manager) for manager in data["propertyManagerIDs"]
             ]
             del data["propertyManagerIDs"]
+        return data
+
+
+class PropertyUpdateSchema(PropertySchema):
+    @pre_load
+    def ignore_name_if_unchanged(self, data, **kwargs):
+        property_to_update = PropertyModel.find(data["id"])
+        if "name" in data and data["name"] == property_to_update.name:
+            del data["name"]
+        del data["id"]
         return data

--- a/schemas/property.py
+++ b/schemas/property.py
@@ -26,9 +26,12 @@ class PropertySchema(ma.SQLAlchemyAutoSchema):
 
     @validates("name")
     def validates_uniqueness_of_name(self, value):
-        if "name" in self.context and value == self.context["name"]:
-            return value
-        if PropertyModel.find_by_name(value):
+        def _assigning_name():
+            if "name" in self.context and value == self.context["name"]:
+                return False
+            return True
+
+        if _assigning_name() and PropertyModel.find_by_name(value):
             raise ValidationError("A property with this name already exists")
 
     @post_load

--- a/schemas/property.py
+++ b/schemas/property.py
@@ -2,7 +2,7 @@ from ma import ma
 from models.property import PropertyModel
 from models.user import UserModel
 from schemas.property_assignment import PropertyAssignSchema
-from marshmallow import fields, validates, ValidationError, post_load, pre_load
+from marshmallow import fields, validates, ValidationError, post_load
 from utils.time import time_format
 
 
@@ -26,6 +26,8 @@ class PropertySchema(ma.SQLAlchemyAutoSchema):
 
     @validates("name")
     def validates_uniqueness_of_name(self, value):
+        if "name" in self.context and value == self.context["name"]:
+            return value
         if PropertyModel.find_by_name(value):
             raise ValidationError("A property with this name already exists")
 
@@ -36,14 +38,4 @@ class PropertySchema(ma.SQLAlchemyAutoSchema):
                 UserModel.find(manager) for manager in data["propertyManagerIDs"]
             ]
             del data["propertyManagerIDs"]
-        return data
-
-
-class PropertyUpdateSchema(PropertySchema):
-    @pre_load
-    def ignore_name_if_unchanged(self, data, **kwargs):
-        property_to_update = PropertyModel.find(data["id"])
-        if "name" in data and data["name"] == property_to_update.name:
-            del data["name"]
-        del data["id"]
         return data

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -1,8 +1,9 @@
 import pytest
+import json
+from conftest import is_valid
 from models.property import PropertyModel
 from models.user import UserModel
 from models.tenant import TenantModel
-import json
 
 
 def test_get_properties(client, test_database):
@@ -215,15 +216,20 @@ def test_delete_property_by_id(client, auth_headers, test_database):
     assert response == 404
 
 
-def test_update_property_by_id(client, auth_headers, create_property, test_database):
+def test_update_property_by_id(client, empty_test_db, valid_header, create_property):
     test_property = create_property()
     new_property_address = "123 NE Flanders St"
-    test_property.address = new_property_address
+
+    property_json = test_property.json()
+
+    property_json["address"] = new_property_address
+
+    response = client.put(
+        f"/api/properties/{test_property.id}",
+        json=property_json,
+        headers=valid_header,
+    )
+    assert is_valid(response, 200)
 
     """The property should have a new address"""
-    test_changed_property = client.get(
-        f"/api/properties/{test_property.id}", headers=auth_headers["admin"]
-    )
-    test_changed_property = json.loads(test_changed_property.data)
-
-    assert test_changed_property["address"] == new_property_address
+    assert response.json["address"] == new_property_address

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -1,6 +1,5 @@
 import pytest
 import json
-from conftest import is_valid
 from models.property import PropertyModel
 from models.user import UserModel
 from models.tenant import TenantModel
@@ -216,7 +215,7 @@ def test_delete_property_by_id(client, auth_headers, test_database):
     assert response == 404
 
 
-def test_update_property_by_id(client, empty_test_db, valid_header, create_property):
+def test_update_property(client, empty_test_db, valid_header, create_property):
     test_property = create_property()
     new_property_address = "123 NE Flanders St"
 
@@ -229,7 +228,7 @@ def test_update_property_by_id(client, empty_test_db, valid_header, create_prope
         json=property_json,
         headers=valid_header,
     )
-    assert is_valid(response, 200)
+    assert response == 200
 
     """The property should have a new address"""
     assert response.json["address"] == new_property_address

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -223,12 +223,31 @@ def test_update_property(client, empty_test_db, valid_header, create_property):
 
     property_json["address"] = new_property_address
 
+    """
+    Updating property info should be successful when the payload includes
+    the property's current name. The response JSON should reflect these changes.
+    """
     response = client.put(
         f"/api/properties/{test_property.id}",
         json=property_json,
         headers=valid_header,
     )
     assert response == 200
+    assert response.json == property_json
 
-    """The property should have a new address"""
-    assert response.json["address"] == new_property_address
+    new_property = create_property()
+    duplicate_name = test_property.name
+
+    new_property_json = new_property.json()
+    new_property_json["name"] = duplicate_name
+
+    """
+    The server responds with a 400 error when attempting to update a
+    property with the name of another existing property.
+    """
+    response = client.put(
+        f"/api/properties/{new_property.id}",
+        json=new_property_json,
+        headers=valid_header,
+    )
+    assert response == 400

--- a/tests/schemas/test_property_schema.py
+++ b/tests/schemas/test_property_schema.py
@@ -61,7 +61,7 @@ class TestPostLoadDeserialization:
         prop = create_property()
         pm_2 = create_property_manager()
         pm_3 = create_property_manager()
-        payload = {"id": prop.id, "propertyManagerIDs": [pm_2.id, pm_3.id]}
+        payload = {"propertyManagerIDs": [pm_2.id, pm_3.id]}
         context = {"request_type": "PUT", "name": prop.name}
 
         PropertyModel.update(
@@ -74,7 +74,6 @@ class TestPostLoadDeserialization:
     def test_property_update_without_managers(self, create_property):
         prop = create_property()
         payload = {
-            "id": prop.id,
             "name": "The New Portlander Delux Apartment Complex Multnomah Suites",
         }
         context = {"request_type": "PUT", "name": prop.name}

--- a/tests/unit/base_interface_test.py
+++ b/tests/unit/base_interface_test.py
@@ -65,7 +65,7 @@ class BaseInterfaceTest:
                 response = self.object.__class__.update(self.schema, 1, {})
 
         mock_find.assert_called_with(1)
-        mock_validate.assert_called_with(self.schema, {}, partial=True)
+        mock_validate.assert_called_with(self.schema, {}, context=None, partial=True)
         mock_session.add.assert_called_with(self.object)
         mock_session.commit.assert_called()
 


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/521
~Closes issue 522~ --moved to a new PR

Assuming we want to handle this on the backend rather than requiring the frontend to only send updated info in payload, this PR solves issue of unique name validation in the PropertySchema.

- Updates property endpoint PUT function to validate using a context dictionary 
- New `PropertySchema` name validation uses a conditional based on the schema's context. This allows for non-unique names in payload if name is unchanged, but validates for uniqueness otherwise
- Refactors existing `update_property_by_id` integration test
- Adds schema tests for new validations

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? NO
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
