### PR TITLE
Tenant json includes only the active lease

### DIFF
--- a/models/lease.py
+++ b/models/lease.py
@@ -1,3 +1,4 @@
+from sqlalchemy.sql.functions import now
 from db import db
 from models.base_model import BaseModel
 from utils.time import Time
@@ -24,3 +25,8 @@ class LeaseModel(BaseModel):
             "dateTimeEnd": Time.format_date(self.dateTimeEnd),
             "unitNum": self.unitNum,
         }
+
+    @classmethod
+    def active(cls):
+        time = now()
+        return (time > cls.dateTimeStart) & (time < cls.dateTimeEnd)

--- a/models/tenant.py
+++ b/models/tenant.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import relationship
 from db import db
 from models.base_model import BaseModel
 from utils.time import Time
+from models.lease import LeaseModel
 
 
 class TenantModel(BaseModel):
@@ -16,17 +17,19 @@ class TenantModel(BaseModel):
     # relationships
     staff = relationship("UserModel", secondary="staff_tenant_links")
     leases = db.relationship(
-        "LeaseModel", backref="tenant", lazy=True, cascade="all, delete-orphan"
+        "LeaseModel", backref="tenant", lazy="dynamic", cascade="all, delete-orphan"
     )
 
     def json(self):
+        first_active_lease = self.leases.filter(LeaseModel.active()).first()
+        active_lease_json = first_active_lease.json() if first_active_lease else ""
         return {
             "id": self.id,
             "firstName": self.firstName,
             "lastName": self.lastName,
             "fullName": "{} {}".format(self.firstName, self.lastName),
             "phone": self.phone,
-            "lease": self.leases[0].json() if self.leases else "",
+            "lease": active_lease_json,
             "staff": [user.json() for user in self.staff] if self.staff else [],
             "created_at": Time.format_date(self.created_at),
             "updated_at": Time.format_date(self.updated_at),

--- a/tests/factory_fixtures/lease.py
+++ b/tests/factory_fixtures/lease.py
@@ -4,15 +4,13 @@ from models.lease import LeaseModel
 
 @pytest.fixture
 def lease_attributes(faker):
-    def _lease_attributes(unitNum, tenant, property):
+    def _lease_attributes(unitNum, tenant, property, dateTimeStart, dateTimeEnd):
         return {
             "unitNum": unitNum,
             "tenantID": tenant.id,
             "propertyID": property.id,
-            "dateTimeStart": faker.date_time_this_decade(),
-            "dateTimeEnd": faker.date_time_this_decade(
-                before_now=False, after_now=True
-            ),
+            "dateTimeStart": dateTimeStart,
+            "dateTimeEnd": dateTimeEnd,
             "occupants": faker.random_number(digits=2),
         }
 
@@ -21,11 +19,23 @@ def lease_attributes(faker):
 
 @pytest.fixture
 def create_lease(faker, lease_attributes, create_property, create_tenant):
-    def _create_lease(tenant=None, property=None, unitNum=None):
+    def _create_lease(
+        tenant=None,
+        property=None,
+        unitNum=None,
+        dateTimeStart=None,
+        dateTimeEnd=None,
+    ):
         unitNum = unitNum or faker.building_number()
         tenant = tenant or create_tenant()
         property = property or create_property()
-        lease = LeaseModel(**lease_attributes(unitNum, tenant, property))
+        dateTimeStart = dateTimeStart or faker.date_time_this_decade()
+        dateTimeEnd = dateTimeEnd or faker.date_time_this_decade(
+            before_now=False, after_now=True
+        )
+        lease = LeaseModel(
+            **lease_attributes(unitNum, tenant, property, dateTimeStart, dateTimeEnd)
+        )
         lease.save_to_db()
         return lease
 

--- a/tests/factory_fixtures/lease.py
+++ b/tests/factory_fixtures/lease.py
@@ -1,5 +1,7 @@
 import pytest
 from models.lease import LeaseModel
+from schemas.lease import LeaseSchema
+from utils.time import Time
 
 
 @pytest.fixture
@@ -9,8 +11,8 @@ def lease_attributes(faker):
             "unitNum": unitNum,
             "tenantID": tenant.id,
             "propertyID": property.id,
-            "dateTimeStart": dateTimeStart,
-            "dateTimeEnd": dateTimeEnd,
+            "dateTimeStart": Time.to_iso(dateTimeStart),
+            "dateTimeEnd": Time.to_iso(dateTimeEnd),
             "occupants": faker.random_number(digits=2),
         }
 
@@ -33,10 +35,10 @@ def create_lease(faker, lease_attributes, create_property, create_tenant):
         dateTimeEnd = dateTimeEnd or faker.date_time_this_decade(
             before_now=False, after_now=True
         )
-        lease = LeaseModel(
-            **lease_attributes(unitNum, tenant, property, dateTimeStart, dateTimeEnd)
+        lease = LeaseModel.create(
+            LeaseSchema,
+            lease_attributes(unitNum, tenant, property, dateTimeStart, dateTimeEnd),
         )
-        lease.save_to_db()
         return lease
 
     yield _create_lease

--- a/tests/unit/test_tenant.py
+++ b/tests/unit/test_tenant.py
@@ -1,7 +1,9 @@
+from models.property import PropertyModel
 import pytest
 from tests.unit.base_interface_test import BaseInterfaceTest
 from models.tenant import TenantModel
 from schemas.tenant import TenantSchema
+import datetime
 
 
 class TestBaseTenantModel(BaseInterfaceTest):
@@ -9,6 +11,28 @@ class TestBaseTenantModel(BaseInterfaceTest):
         self.object = TenantModel()
         self.custom_404_msg = "Tenant not found"
         self.schema = TenantSchema
+
+    def test_only_active_lease_returned(self, faker, create_lease, create_tenant):
+        tenant = create_tenant()
+
+        # Create an expired lease for the tenant
+        lease_expired_end = faker.date_time_this_decade(
+            before_now=True, after_now=False
+        )
+        lease_expired_start = lease_expired_end - datetime.timedelta(days=365)
+        lease_expired = create_lease(
+            tenant=tenant,
+            dateTimeStart=lease_expired_start,
+            dateTimeEnd=lease_expired_end,
+        )
+
+        # Create an active lease for the tenant
+        lease_active = create_lease(
+            tenant=tenant, property=PropertyModel.find_by_id(lease_expired.propertyID)
+        )
+
+        # Active lease should be the only one that shows up
+        assert tenant.json()["lease"] == lease_active.json()
 
 
 @pytest.mark.usefixtures("empty_test_db")

--- a/tests/unit/test_tenant.py
+++ b/tests/unit/test_tenant.py
@@ -28,7 +28,7 @@ class TestBaseTenantModel(BaseInterfaceTest):
 
         # Create an active lease for the tenant
         lease_active = create_lease(
-            tenant=tenant, property=PropertyModel.find_by_id(lease_expired.propertyID)
+            tenant=tenant, property=PropertyModel.find(lease_expired.propertyID)
         )
 
         # Active lease should be the only one that shows up


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/512

Previously, `TenantModel.json()` filled out the `'lease'` field by getting the first lease returned. Now, we filter the list of leases using the new `TenantModel.active()` class method, which returns a SQLalchemy filter filtering out inactive leases. Currently, we just return the first of those active leases.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? NO
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
