### PR TITLE
Fix bug for retrieving PMs and their tenants through the Users endpont

### DIFF
--- a/resources/user.py
+++ b/resources/user.py
@@ -2,7 +2,6 @@ from flask_restful import Resource, reqparse
 from flask import request
 from schemas import UserRegisterSchema
 from models.property import PropertyModel
-from models.tenant import TenantModel
 from utils.authorizations import admin_required, admin, pm_level_required
 from models.user import UserModel, RoleEnum
 from models.revoked_tokens import RevokedTokensModel

--- a/resources/user.py
+++ b/resources/user.py
@@ -36,10 +36,7 @@ class UserRegister(Resource):
 class User(Resource):
     @admin_required
     def get(self, user_id):
-        user = UserModel.find_by_id(user_id)
-
-        if not user:
-            return {"message": "User not found"}, 404
+        user = UserModel.find(user_id)
 
         user_info = user.json()
 

--- a/tests/factory_fixtures/lease.py
+++ b/tests/factory_fixtures/lease.py
@@ -20,12 +20,15 @@ def lease_attributes(faker):
 
 
 @pytest.fixture
-def create_lease(faker, lease_attributes, create_property, create_tenant):
-    def _create_lease(unitNum=None):
+def create_lease(
+    faker, lease_attributes, create_property, create_tenant, tenant=None, property=None
+):
+    def _create_lease(tenant=tenant, property=property, unitNum=None):
         if not unitNum:
             unitNum = faker.building_number()
-        tenant = create_tenant()
-        lease = LeaseModel(**lease_attributes(unitNum, tenant, create_property()))
+        tenant = tenant or create_tenant()
+        property = property or create_property()
+        lease = LeaseModel(**lease_attributes(unitNum, tenant, property))
         lease.save_to_db()
         return lease
 

--- a/tests/factory_fixtures/lease.py
+++ b/tests/factory_fixtures/lease.py
@@ -20,12 +20,9 @@ def lease_attributes(faker):
 
 
 @pytest.fixture
-def create_lease(
-    faker, lease_attributes, create_property, create_tenant, tenant=None, property=None
-):
-    def _create_lease(tenant=tenant, property=property, unitNum=None):
-        if not unitNum:
-            unitNum = faker.building_number()
+def create_lease(faker, lease_attributes, create_property, create_tenant):
+    def _create_lease(tenant=None, property=None, unitNum=None):
+        unitNum = unitNum or faker.building_number()
         tenant = tenant or create_tenant()
         property = property or create_property()
         lease = LeaseModel(**lease_attributes(unitNum, tenant, property))

--- a/tests/factory_fixtures/property.py
+++ b/tests/factory_fixtures/property.py
@@ -23,10 +23,10 @@ def property_attributes(faker, create_property_manager):
 
 
 @pytest.fixture
-def create_property(property_attributes):
-    def _create_property():
+def create_property(property_attributes, **kwargs):
+    def _create_property(**kwargs):
         property = PropertyModel.create(
-            payload=property_attributes(), schema=PropertySchema
+            payload=property_attributes(**kwargs), schema=PropertySchema
         )
         return property
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -81,17 +81,17 @@ def test_refresh_user(client, test_database, admin_user):
     assert responseRefreshToken.status_code == 200
 
 
-def test_get_user_by_id(client, empty_test_db, create_admin_user, admin_header):
+def test_get_user_by_id(client, empty_test_db, create_admin_user, valid_header):
     """The get user by id route returns a successful response code."""
     user = create_admin_user()
-    response = client.get(f"/api/user/{user.id}", headers=admin_header)
+    response = client.get(f"/api/user/{user.id}", headers=valid_header)
     assert response.status_code == 200
 
     """
     The server responds with an error if a non-existent user id
     is requested from the get user by id route.
     """
-    responseBadUserId = client.get("/api/user/000000", headers=admin_header)
+    responseBadUserId = client.get("/api/user/000000", headers=valid_header)
     assert responseBadUserId.status_code == 404
     assert responseBadUserId.json == {"message": "User not found"}
 
@@ -102,19 +102,22 @@ def test_get_pm_by_id(
     create_property_manager,
     create_property,
     create_lease,
-    admin_header,
+    valid_header,
 ):
     user = create_property_manager()
     prop = create_property(manager_ids=[user.id])
     lease_1 = create_lease(property=prop)
     lease_2 = create_lease(property=prop)
 
-    response = client.get(f"/api/user/{user.id}", headers=admin_header)
+    response = client.get(f"/api/user/{user.id}", headers=valid_header)
 
     property_list = response.json["properties"]
     tenants_list = response.json["tenants"]
 
-    """The get user by id route returns a successful response code for PMs"""
+    """
+    The get user by id route returns a successful response code
+    when the queried user is a property manager
+    """
     assert response.status_code == 200
 
     """The PM's properties are returned as a list of JSON objects"""

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -81,19 +81,50 @@ def test_refresh_user(client, test_database, admin_user):
     assert responseRefreshToken.status_code == 200
 
 
-def test_get_user_by_id(client, auth_headers, admin_user):
+def test_get_user_by_id(client, empty_test_db, create_admin_user, admin_header):
     """The get user by id route returns a successful response code."""
-    user = UserModel.find_by_email(admin_user.email)
-    response = client.get(f"/api/user/{user.id}", headers=auth_headers["admin"])
+    user = create_admin_user()
+    response = client.get(f"/api/user/{user.id}", headers=admin_header)
     assert response.status_code == 200
 
     """
     The server responds with an error if a non-existent user id
     is requested from the get user by id route.
     """
-    responseBadUserId = client.get("/api/user/000000", headers=auth_headers["admin"])
+    responseBadUserId = client.get("/api/user/000000", headers=admin_header)
     assert responseBadUserId.status_code == 404
     assert responseBadUserId.json == {"message": "User not found"}
+
+
+def test_get_pm_by_id(
+    client,
+    empty_test_db,
+    create_property_manager,
+    create_property,
+    create_lease,
+    admin_header,
+):
+    user = create_property_manager()
+    prop = create_property(manager_ids=[user.id])
+    lease_1 = create_lease(property=prop)
+    lease_2 = create_lease(property=prop)
+
+    response = client.get(f"/api/user/{user.id}", headers=admin_header)
+
+    property_list = response.json["properties"]
+    tenants_list = response.json["tenants"]
+
+    """The get user by id route returns a successful response code for PMs"""
+    assert response.status_code == 200
+
+    """The PM's properties are returned as a list of JSON objects"""
+    assert property_list == [prop.json()]
+
+    """
+    Tenants are retreived through the leases on each
+    property and returned as a list of JSON objects
+    """
+    assert tenants_list == [lease_1.tenant.json(), lease_2.tenant.json()]
 
 
 def test_user_roles(client, auth_headers):


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/522

This was cherry picked over from changes originally made by me and @DaveTrost in #209 

Fixes a recent break where Property managers could no longer be retrieved through the users/<id> endpoint due to a change in how the attached tenants were being handled.  I also added an integration test and updated some pytest fixtures, since the breaking change slipped through the cracks of our previous tests.

The serialization of a Property Manager's tenants data is still being handled in the endpoint.  A new issue will be opened up to migrate that serialization over to the model.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? NO
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
