### PR TITLE
Remove final remnants of PENDING role

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -45,7 +45,6 @@ def new_user():
         firstName="user2",
         lastName="tester",
         phone="1-888-cal-saul",
-        role=RoleEnum.PENDING,
         archived=0,
     )
     return newUser
@@ -70,12 +69,10 @@ def property_manager_user():
 def auth_headers(client, test_database, admin_user, new_user, property_manager_user):
     admin_auth_header = get_auth_header(client, admin_user)
     pm_auth_header = get_auth_header(client, property_manager_user)
-    pending_auth_header = get_auth_header(client, new_user)
 
     return {
         "admin": admin_auth_header,
         "pm": pm_auth_header,
-        "pending": pending_auth_header,
     }
 
 

--- a/models/user.py
+++ b/models/user.py
@@ -13,7 +13,6 @@ from sqlalchemy import and_
 
 
 class RoleEnum(Enum):
-    PENDING = 0
     PROPERTY_MANAGER = 2
     STAFF = 3
     ADMIN = 4

--- a/tests/integration/test_emergency_contacts.py
+++ b/tests/integration/test_emergency_contacts.py
@@ -78,9 +78,6 @@ def test_emergency_contacts_POST(client, auth_headers):
     response = client.post(endpoint, json=newContact, headers=auth_headers["pm"])
     assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
-    response = client.post(endpoint, json=newContact, headers=auth_headers["pending"])
-    assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
-
     response = client.post(endpoint, json=newContact)
     assert is_valid(response, 401)  # UNAUTHORIZED - Missing Authorization Header
     assert response.json == {"message": "Missing authorization header"}
@@ -132,9 +129,6 @@ def test_emergency_contacts_DELETE(client, auth_headers):
     response = client.delete(f"{endpoint}/{id}")
     assert is_valid(response, 401)  # UNAUTHORIZED - Missing Authorization Header
     assert response.json == {"message": "Missing authorization header"}
-
-    response = client.delete(f"{endpoint}/{id}", headers=auth_headers["pending"])
-    assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
     response = client.delete(f"{endpoint}/{id}", headers=auth_headers["pm"])
     assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required

--- a/tests/integration/test_tenants.py
+++ b/tests/integration/test_tenants.py
@@ -64,9 +64,6 @@ def test_tenants_POST(
     response = client.post(endpoint, json=newTenant, headers=auth_headers["pm"])
     assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
-    response = client.post(endpoint, json=newTenant, headers=auth_headers["pending"])
-    assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
-
     response = client.post(endpoint, json=newTenant)
     # UNAUTHORIZED - Missing Authorization Header
     assert is_valid(response, 401)
@@ -102,12 +99,6 @@ def test_unauthenticated_delete(client):
 
     assert is_valid(response, 401)
     assert response.json == {"message": "Missing authorization header"}
-
-
-def test_pending_role_is_unauthorized_to_delete(client, auth_headers):
-    response = client.delete(f"{endpoint}/1", headers=auth_headers["pending"])
-
-    assert is_valid(response, 401)
 
 
 def test_pm_role_is_unauthorized_to_delete(client, auth_headers):

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -364,11 +364,6 @@ def test_delete_user(client, auth_headers, new_user, admin_user):
     assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
     response = client.delete(
-        f"/api/user/{userToDelete.id}", headers=auth_headers["pending"]
-    )
-    assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
-
-    response = client.delete(
         f"/api/user/{userToDelete.id}", headers=auth_headers["admin"]
     )
     assert is_valid(response, 200)  # OK


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/504

Remove final remnants of PENDING role with the following changes:
- Remove PENDING from `RoleEnum`
- Remove pending user from `auth_header`
- Remove tests that use `pending_auth_header`


### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? I don't think so, but it couldn't hurt.
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
