### PR TITLE
Allow for tenants to be unarchived

### DIFF
--- a/resources/tenants.py
+++ b/resources/tenants.py
@@ -67,7 +67,17 @@ class Tenants(Resource):
         tenant = TenantModel.find_by_id(tenant_id)
         if not tenant:
             return {"message": "Tenant not found"}, 404
-        # Do not delete the tenant, just archive
-        tenant.archived = True
-        tenant.save_to_db()
-        return {"message": "Tenant archived"}
+
+        def _toggle_archive():
+            if tenant.archived:
+                tenant.archived = False
+                status = {"message": "Tenant unarchived"}
+            else:
+                tenant.archived = True
+                status = {"message": "Tenant archived"}
+
+            tenant.save_to_db()
+            return status
+
+        response = _toggle_archive()
+        return response

--- a/resources/tenants.py
+++ b/resources/tenants.py
@@ -64,9 +64,7 @@ class Tenants(Resource):
 
     @admin_required
     def delete(self, tenant_id):
-        tenant = TenantModel.find_by_id(tenant_id)
-        if not tenant:
-            return {"message": "Tenant not found"}, 404
+        tenant = TenantModel.find(tenant_id)
 
         def _toggle_archive():
             if tenant.archived:

--- a/tests/integration/test_tenants.py
+++ b/tests/integration/test_tenants.py
@@ -130,7 +130,7 @@ class TestTenantsDelete:
 
     def test_delete_can_unarchive_tenant(self, valid_header, create_tenant):
         tenant = create_tenant()
-        self.client.delete(f"{endpoint}/{tenant.id}", headers=valid_header)
+        tenant.archived = True
 
         response = self.client.delete(f"{endpoint}/{tenant.id}", headers=valid_header)
 

--- a/tests/integration/test_tenants.py
+++ b/tests/integration/test_tenants.py
@@ -1,3 +1,4 @@
+import pytest
 from conftest import is_valid
 from utils.time import Time
 
@@ -116,3 +117,23 @@ def test_resource_not_found(client, auth_headers):
     response = client.delete(f"{endpoint}/10000", headers=auth_headers["admin"])
     assert is_valid(response, 404)
     assert response.json == {"message": "Tenant not found"}
+
+
+@pytest.mark.usefixtures("client_class", "empty_test_db")
+class TestTenantsDelete:
+    def test_delete_archives_tenant(self, valid_header, create_tenant):
+        tenant = create_tenant()
+        response = self.client.delete(f"{endpoint}/{tenant.id}", headers=valid_header)
+        assert response == 200
+        assert tenant.archived
+        assert response.json == {"message": "Tenant archived"}
+
+    def test_delete_can_unarchive_tenant(self, valid_header, create_tenant):
+        tenant = create_tenant()
+        self.client.delete(f"{endpoint}/{tenant.id}", headers=valid_header)
+
+        response = self.client.delete(f"{endpoint}/{tenant.id}", headers=valid_header)
+
+        assert response == 200
+        assert not tenant.archived
+        assert response.json == {"message": "Tenant unarchived"}


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/519

Changes:
- Add logic to unarchive tenants in `tenants/delete` endpoint
- Add integration tests to confirm successful archival and unarchival

I made a new class for these tests, but didn't add in the previously-written `delete` endpoint tests since those seem to be testing authorization and will likely be moved soon.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? NO
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
