### PR TITLE
Issue532 archive property endpoint update

### DIFF
--- a/resources/property.py
+++ b/resources/property.py
@@ -42,8 +42,12 @@ class ArchiveProperty(Resource):
         property.archived = not property.archived
 
         property.save_to_db()
-
-        return property.json(), 201
+        message = (
+            "Property archived successfully"
+            if property.archived
+            else "Property unarchived successfully"
+        )
+        return {"message": message}, 200
 
 
 class ArchiveProperties(Resource):

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -73,11 +73,11 @@ def test_archive_property_by_id(client, auth_headers, create_property, test_data
     assert responseNoAdmin == 401
     assert responseNoAdmin.json == {"message": "Missing authorization header"}
 
-    """The archive property endpoint should return a 201 code when successful"""
+    """The archive property endpoint should return a 200 code when successful"""
     responseSuccess = client.post(
         f"/api/properties/archive/{test_property.id}", headers=auth_headers["admin"]
     )
-    assert responseSuccess.status_code == 201
+    assert responseSuccess.status_code == 200
 
     """The property should have its 'archived' key set to True"""
     responseArchivedProperty = client.get(


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/532

Not directly related to issue 532, but close enough. The property archive endpoint should just return a success or error message instead of the whole property json. It should also be a 200 instead of a 201 since we are not "Creating" anything with this endpoint.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? n
Any new dependencies to install? n
Any special requirements to test? n

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
