### PR TITLE
Separate emergency contacts auth tests

### DIFF
--- a/tests/authorizations/test_emergency_contact_authorization.py
+++ b/tests/authorizations/test_emergency_contact_authorization.py
@@ -1,0 +1,43 @@
+from conftest import is_valid
+import pytest
+
+
+@pytest.mark.usefixtures("client_class", "empty_test_db")
+class TestEmergenyContactsAuthorizations:
+    def setup(self):
+        self.endpoint = "/api/emergencycontacts"
+
+    def test_emergency_contacts_POST(self, auth_headers):
+        endpoint = "/api/emergencycontacts"
+
+        newContact = {
+            "name": "Narcotics Anonymous",
+            "description": "Cool description",
+            "contact_numbers": [
+                {"number": "503-291-9111", "numtype": "Call"},
+                {"number": "503-555-3321", "numtype": "Text"},
+            ],
+        }
+
+        response = self.client.post(
+            endpoint, json=newContact, headers=auth_headers["pm"]
+        )
+        assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
+
+        response = self.client.post(endpoint, json=newContact)
+        assert is_valid(response, 401)  # UNAUTHORIZED - Missing Authorization Header
+        assert response.json == {"message": "Missing authorization header"}
+
+    def test_emergency_contacts_DELETE(self, auth_headers):
+        endpoint = "/api/emergencycontacts"
+
+        id = 1
+
+        response = self.client.delete(f"{endpoint}/{id}")
+        assert is_valid(response, 401)  # UNAUTHORIZED - Missing Authorization Header
+        assert response.json == {"message": "Missing authorization header"}
+
+        response = self.client.delete(f"{endpoint}/{id}", headers=auth_headers["pm"])
+        assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
+
+

--- a/tests/integration/test_emergency_contacts.py
+++ b/tests/integration/test_emergency_contacts.py
@@ -75,13 +75,6 @@ def test_emergency_contacts_POST(client, auth_headers):
         "message": {"contact_numbers": {"0": {"number": ["Not a valid string."]}}}
     }
 
-    response = client.post(endpoint, json=newContact, headers=auth_headers["pm"])
-    assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
-
-    response = client.post(endpoint, json=newContact)
-    assert is_valid(response, 401)  # UNAUTHORIZED - Missing Authorization Header
-    assert response.json == {"message": "Missing authorization header"}
-
     newContact["name"] = "Cooler Name"
     response = client.post(endpoint, json=newContact, headers=auth_headers["admin"])
     assert is_valid(response, 201)  # CREATED
@@ -125,13 +118,6 @@ def test_emergency_contacts_PUT(client, auth_headers):
 
 def test_emergency_contacts_DELETE(client, auth_headers):
     id = 1
-
-    response = client.delete(f"{endpoint}/{id}")
-    assert is_valid(response, 401)  # UNAUTHORIZED - Missing Authorization Header
-    assert response.json == {"message": "Missing authorization header"}
-
-    response = client.delete(f"{endpoint}/{id}", headers=auth_headers["pm"])
-    assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
     response = client.delete(f"{endpoint}/{id}", headers=auth_headers["admin"])
     assert is_valid(response, 200)  # OK


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/545

Moves emergency contact auth tests into their own file.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? NO
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
