### PR TITLE
Property serialization includes only tenants with active lease

### DIFF
--- a/models/lease.py
+++ b/models/lease.py
@@ -2,6 +2,7 @@ from sqlalchemy.sql.functions import now
 from db import db
 from models.base_model import BaseModel
 from utils.time import Time
+from datetime import datetime
 
 
 class LeaseModel(BaseModel):
@@ -25,6 +26,10 @@ class LeaseModel(BaseModel):
             "dateTimeEnd": Time.format_date(self.dateTimeEnd),
             "unitNum": self.unitNum,
         }
+
+    def is_active(self):
+        now = datetime.now()
+        return now > self.dateTimeStart and now < self.dateTimeEnd
 
     @classmethod
     def active(cls):

--- a/models/property.py
+++ b/models/property.py
@@ -52,7 +52,8 @@ class PropertyModel(BaseModel):
     def tenants(self):
         tenants = []
         for lease in self.leases:
-            tenants.append(lease.tenant.json())
+            if lease.is_active():
+                tenants.append(lease.tenant.json())
         return tenants
 
     @classmethod

--- a/tests/unit/test_property.py
+++ b/tests/unit/test_property.py
@@ -2,6 +2,8 @@ import pytest
 from tests.unit.base_interface_test import BaseInterfaceTest
 from models.property import PropertyModel
 from schemas.property import PropertySchema
+from utils.time import Time
+from dateutil.relativedelta import relativedelta
 
 
 class TestBasePropertyModel(BaseInterfaceTest):
@@ -46,3 +48,22 @@ class TestPropertyModel:
         tenant = lease.tenant
 
         assert property.json(include_tenants=True)["tenants"] == [tenant.json()]
+
+    def test_only_active_tenants_included(self, create_lease):
+        active_lease = create_lease()
+
+        old_lease_end = Time._yesterday()
+        old_lease_start = old_lease_end - relativedelta(years=1)
+        expired_lease = create_lease(
+            property=active_lease.property,
+            dateTimeStart=old_lease_start,
+            dateTimeEnd=old_lease_end,
+        )
+
+        property = PropertyModel.find(expired_lease.propertyID)
+        property_json = property.json()
+
+        assert len(property_json["tenants"]) == 1
+        assert len(property_json["lease"]) == 2
+        assert active_lease.tenant.json() in property_json["tenants"]
+        assert expired_lease.tenant.json() not in property_json["tenants"]

--- a/tests/unit/test_property.py
+++ b/tests/unit/test_property.py
@@ -61,9 +61,9 @@ class TestPropertyModel:
         )
 
         property = PropertyModel.find(expired_lease.propertyID)
-        property_json = property.json()
+        property_json = property.json(include_tenants=True)
 
         assert len(property_json["tenants"]) == 1
-        assert len(property_json["lease"]) == 2
+        assert len(property_json["leases"]) == 2
         assert active_lease.tenant.json() in property_json["tenants"]
         assert expired_lease.tenant.json() not in property_json["tenants"]


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/520

Serialization of a property's tenants has been moved out of the endpoint and into the `json()` method. 
The `tenants()` method in `PropertyModel` now only includes tenants with currently active leases.

Added another unit test for the `tenants()` method and refactored the relevant integration test.


### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? NO
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
