### PR TITLE
Add backref for StaffTenant relationship

### DIFF
--- a/models/staff_tenant_link.py
+++ b/models/staff_tenant_link.py
@@ -1,7 +1,4 @@
 from db import db
-from sqlalchemy.orm import relationship
-from models.tenant import TenantModel
-from models.user import UserModel
 from models.base_model import BaseModel
 
 
@@ -9,8 +6,6 @@ class StaffTenantLink(BaseModel):
     __tablename__ = "staff_tenant_links"
     tenant_id = db.Column(db.Integer, db.ForeignKey("tenants.id"), primary_key=True)
     staff_id = db.Column(db.Integer, db.ForeignKey("users.id"), primary_key=True)
-    tenant = relationship(TenantModel)
-    staff = relationship(UserModel)
 
     # might want to set up relationships and backref's?
     # import from sqlalchemy.orm

--- a/models/tenant.py
+++ b/models/tenant.py
@@ -16,7 +16,7 @@ class TenantModel(BaseModel):
     archived = db.Column(db.Boolean, default=False, nullable=False)
 
     # relationships
-    staff = relationship("UserModel", secondary="staff_tenant_links")
+    staff = relationship("UserModel", secondary="staff_tenant_links", backref="tenants")
     leases = db.relationship(
         "LeaseModel", backref="tenant", lazy="dynamic", cascade="all, delete-orphan"
     )


### PR DESCRIPTION
Added backref so that we can ask these queries. `staff_user.tenants` and `tenant.staff`

Removed the staff and tenant relationship on the StaffTenant table. It is not necessary to have these and they were generating the below warnings. If we need to work with the table directly in the future and need to make such queries then we can adjust at that time.

```
python3.8/site-packages/sqlalchemy/orm/relationships.py:3435: SAWarning: relationship 'StaffTenantLink.tenant' will copy column tenants.id to column staff_tenant_links.tenant_id, which conflicts with relationship(s): 'TenantModel.staff' (copies tenants.id to staff_tenant_links.tenant_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   The 'overlaps' parameter may be used to remove this warning.
  util.warn(
python3.8/site-packages/sqlalchemy/orm/relationships.py:3435: SAWarning: relationship 'StaffTenantLink.staff' will copy column users.id to column staff_tenant_links.staff_id, which conflicts with relationship(s): 'TenantModel.staff' (copies users.id to staff_tenant_links.staff_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   The 'overlaps' parameter may be used to remove this warning.
  util.warn(
```

Fixes codeforpdx/dwellingly-app/issues/567