### PR TITLE
adds authorID to note creation

### DIFF
--- a/resources/tickets.py
+++ b/resources/tickets.py
@@ -12,6 +12,7 @@ class Ticket(Resource):
     parser.add_argument("urgency")
     parser.add_argument("issue")
     parser.add_argument("note")
+    parser.add_argument("authorID")
     parser.add_argument("assignedUserID")
 
     @pm_level_required
@@ -48,7 +49,7 @@ class Ticket(Resource):
             ticket.issue = data.issue
 
         if data.note:
-            note = NotesModel(ticketid=id, text=data.note, userid=ticket.senderID)
+            note = NotesModel(ticketid=id, text=data.note, userid=data.authorID)
             note.save_to_db()
 
         ticket.save_to_db()

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -89,6 +89,7 @@ def test_tickets_PUT(client, auth_headers):
         "urgency": "high",
         "issue": "Leaky pipe",
         "note": "Tenant has a service dog",
+        "authorID": 2,
     }
 
     response = client.put(


### PR DESCRIPTION
### What issue is this solving?
Ticket: #575
When adding a note to a ticket, that note's userid is now assigned to the author of the note, rather than the author of the ticket.  

I attempted to make the changes as cleanly as possible.  Please let me know if there is a better way to do this.  Thanks!

Closes codeforpdx/dwellingly-app/issues/575

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary?
Any new dependencies to install?
Any special requirements to test?

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
