### PR TITLE
Remove tenant endpont DELETE action

### DIFF
--- a/resources/tenants.py
+++ b/resources/tenants.py
@@ -58,21 +58,3 @@ class Tenants(Resource):
         return TenantModel.update(
             schema=TenantSchema, payload=request.json, id=tenant_id
         ).json()
-
-    @admin_required
-    def delete(self, tenant_id):
-        tenant = TenantModel.find(tenant_id)
-
-        def _toggle_archive():
-            if tenant.archived:
-                tenant.archived = False
-                status = {"message": "Tenant unarchived"}
-            else:
-                tenant.archived = True
-                status = {"message": "Tenant archived"}
-
-            tenant.save_to_db()
-            return status
-
-        response = _toggle_archive()
-        return response

--- a/tests/authorizations/test_tenant_authorization.py
+++ b/tests/authorizations/test_tenant_authorization.py
@@ -25,20 +25,3 @@ class TestTenantAuthorization:
         # UNAUTHORIZED - Missing Authorization Header
         assert is_valid(response, 401)
         assert response.json == {"message": "Missing authorization header"}
-
-    def test_unauthenticated_delete(self):
-        response = self.client.delete(f"{self.endpoint}/1")
-
-        assert is_valid(response, 401)
-        assert response.json == {"message": "Missing authorization header"}
-
-    def test_pm_role_is_unauthorized_to_delete(self, auth_headers):
-        response = self.client.delete(f"{self.endpoint}/1", headers=auth_headers["pm"])
-
-        assert is_valid(response, 401)
-
-    def test_admin_is_authorized_to_delete(self, auth_headers):
-        response = self.client.delete(
-            f"{self.endpoint}/1", headers=auth_headers["admin"]
-        )
-        assert is_valid(response, 200)

--- a/tests/integration/test_tenants.py
+++ b/tests/integration/test_tenants.py
@@ -1,6 +1,9 @@
 import pytest
 from conftest import is_valid
+from models.tenant import TenantModel
+from schemas.tenant import TenantSchema
 from utils.time import Time
+from unittest.mock import patch
 
 endpoint = "/api/tenants"
 
@@ -63,52 +66,24 @@ def test_tenants_POST(
     response = client.post(endpoint, json=newTenant, headers=valid_header)
 
 
-def test_tenants_PUT(
-    client, empty_test_db, valid_header, create_tenant, create_join_staff
-):
-    tenant = create_tenant()
-    staff_1 = create_join_staff()
-    staff_2 = create_join_staff()
-    updatedTenant = {
-        "firstName": "Jake",
-        "lastName": "The Dog",
-        "phone": "111-111-1111",
-        "staffIDs": [staff_1.id, staff_2.id],
-    }
-    response = client.put(
-        f"{endpoint}/{tenant.id}", json=updatedTenant, headers=valid_header
-    )
-    assert is_valid(response, 200)  # OK
-    assert response.json["firstName"] == "Jake"
-
-    id = 100
-    response = client.put(f"{endpoint}/{id}", json=updatedTenant, headers=valid_header)
-    assert is_valid(response, 404)  # NOT FOUND
-    assert response.json == {"message": "Tenant not found"}
-
-
-def test_resource_not_found(client, auth_headers):
-    response = client.delete(f"{endpoint}/10000", headers=auth_headers["admin"])
-    assert is_valid(response, 404)
-    assert response.json == {"message": "Tenant not found"}
-
-
 @pytest.mark.usefixtures("client_class", "empty_test_db")
-class TestTenantsDelete:
-    def test_delete_archives_tenant(self, valid_header, create_tenant):
+class TestTenant:
+    def setup(self):
+        self.endpoint = "/api/tenants"
+
+    def test_update_tenant(self, empty_test_db, valid_header, create_tenant):
         tenant = create_tenant()
-        response = self.client.delete(f"{endpoint}/{tenant.id}", headers=valid_header)
-        assert response == 200
-        assert tenant.archived
-        assert response.json == {"message": "Tenant archived"}
+        updated_fields = {"archived": True}
 
-    def test_delete_can_unarchive_tenant(self, valid_header, create_tenant):
-        tenant = create_tenant()
-        tenant.archived = True
-        tenant.save_to_db()
+        with patch.object(TenantModel, "update", return_value=tenant) as mock_update:
+            response = self.client.put(
+                f"{self.endpoint}/{tenant.id}",
+                json=updated_fields,
+                headers=valid_header,
+            )
 
-        response = self.client.delete(f"{endpoint}/{tenant.id}", headers=valid_header)
-
-        assert response == 200
-        assert not tenant.archived
-        assert response.json == {"message": "Tenant unarchived"}
+        mock_update.assert_called_once_with(
+            schema=TenantSchema, id=tenant.id, payload=updated_fields
+        )
+        assert response.status_code == 200
+        assert response.json == tenant.json()


### PR DESCRIPTION
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/591

Removed the `delete()` method from this resource and refactored the
update tenant endpoint test.

The `delete()` method was being used for archiving tenants through a
"toggle" mechanism that would archive the tenant if they were active and
unarchive them if they were already archived.

This required the front end to be aware of a tenant's archival status
before making the request, or else risk accidentally doing the opposite
of what was intended.

Rather than risk this and write additional logic for custom
messages on the back end, we decided to switch to a more deterministic
(and simple) approach by using the existing PUT action to handle
archival.

Success messages can be handled by the front end (as with all update
actions) and the built-in error messages are returned by the back end.

### Any helpful knowledge/context for the reviewer?
Is a re-seeding of the database necessary? NO
Any new dependencies to install? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
