### PR TITLE
Update ticket model & schema

### DIFF
--- a/data/seedData.py
+++ b/data/seedData.py
@@ -208,38 +208,34 @@ def seedData():
 
     ticket_roof_on_fire = TicketModel(
         issue="The roof, the roof, the roof is on fire.",
-        tenantID=tenant_renty_mcrenter.id,
-        senderID=user_1.id,
+        tenant_id=tenant_renty_mcrenter.id,
+        creator_id=user_1.id,
         status=TicketStatus.In_Progress,
         urgency="Low",
-        assignedUserID=user_mister_sir.id,
     )
     ticket_roof_on_fire.save_to_db()
     ticket_dumpster_fire = TicketModel(
         issue="Flaming Dumpster Fire.",
-        tenantID=tenant_soho_muless.id,
-        senderID=user_3.id,
+        tenant_id=tenant_soho_muless.id,
+        creator_id=user_3.id,
         status=TicketStatus.New,
         urgency="Critical",
-        assignedUserID=user_mister_sir.id,
     )
     ticket_dumpster_fire.save_to_db()
     ticket_unpaid_rent = TicketModel(
         issue="Unpaid Rent",
-        tenantID=tenant_renty_mcrenter.id,
-        senderID=user_1.id,
+        tenant_id=tenant_renty_mcrenter.id,
+        creator_id=user_1.id,
         status=TicketStatus.New,
         urgency="High",
-        assignedUserID=user_mister_sir.id,
     )
     ticket_unpaid_rent.save_to_db()
     ticket_40_cats = TicketModel(
         issue="Over 40 cats in domicile.",
-        tenantID=tenant_soho_muless.id,
-        senderID=user_3.id,
+        tenant_id=tenant_soho_muless.id,
+        creator_id=user_3.id,
         status=TicketStatus.Closed,
         urgency="Low",
-        assignedUserID=user_mister_sir.id,
     )
     ticket_40_cats.save_to_db()
 

--- a/data/seedData.py
+++ b/data/seedData.py
@@ -209,7 +209,7 @@ def seedData():
     ticket_roof_on_fire = TicketModel(
         issue="The roof, the roof, the roof is on fire.",
         tenant_id=tenant_renty_mcrenter.id,
-        creator_id=user_1.id,
+        author_id=user_1.id,
         status=TicketStatus.In_Progress,
         urgency="Low",
     )
@@ -217,7 +217,7 @@ def seedData():
     ticket_dumpster_fire = TicketModel(
         issue="Flaming Dumpster Fire.",
         tenant_id=tenant_soho_muless.id,
-        creator_id=user_3.id,
+        author_id=user_3.id,
         status=TicketStatus.New,
         urgency="Critical",
     )
@@ -225,7 +225,7 @@ def seedData():
     ticket_unpaid_rent = TicketModel(
         issue="Unpaid Rent",
         tenant_id=tenant_renty_mcrenter.id,
-        creator_id=user_1.id,
+        author_id=user_1.id,
         status=TicketStatus.New,
         urgency="High",
     )
@@ -233,7 +233,7 @@ def seedData():
     ticket_40_cats = TicketModel(
         issue="Over 40 cats in domicile.",
         tenant_id=tenant_soho_muless.id,
-        creator_id=user_3.id,
+        author_id=user_3.id,
         status=TicketStatus.Closed,
         urgency="Low",
     )

--- a/models/tickets.py
+++ b/models/tickets.py
@@ -17,12 +17,10 @@ class TicketModel(BaseModel):
 
     id = db.Column(db.Integer, primary_key=True)
     issue = db.Column(db.String(144))
-    tenantID = db.Column(db.Integer, db.ForeignKey("tenants.id"))
-    assignedUserID = db.Column(db.Integer, db.ForeignKey("users.id"))
-    senderID = db.Column(db.Integer, db.ForeignKey("users.id"))
-    status = db.Column(db.Enum(TicketStatus))
+    tenant_id = db.Column(db.Integer, db.ForeignKey("tenants.id"))
+    creator_id = db.Column(db.Integer, db.ForeignKey("users.id"))
+    status = db.Column(db.Enum(TicketStatus), default=TicketStatus.New)
     urgency = db.Column(db.String(12))
-    notelog = db.Column(db.Text)
 
     notes = db.relationship(
         "NotesModel",
@@ -39,11 +37,10 @@ class TicketModel(BaseModel):
             "id": self.id,
             "issue": self.issue,
             "tenant": "{} {}".format(self.tenant.firstName, self.tenant.lastName),
-            "senderID": self.senderID,
-            "tenantID": self.tenantID,
-            "assignedUserID": self.assignedUserID,
+            "creator_id": self.creator_id,
+            "tenant_id": self.tenant_id,
+            "assigned_staff": self.tenant.staff.json(),
             "sender": self.author.full_name(),
-            "assigned": self.assignee.full_name(),
             "status": self.status,
             "minsPastUpdate": minsPastUpdate,
             "urgency": self.urgency,

--- a/models/tickets.py
+++ b/models/tickets.py
@@ -17,9 +17,9 @@ class TicketModel(BaseModel):
 
     id = db.Column(db.Integer, primary_key=True)
     issue = db.Column(db.String(144))
-    tenant_id = db.Column(db.Integer, db.ForeignKey("tenants.id"))
-    creator_id = db.Column(db.Integer, db.ForeignKey("users.id"))
-    status = db.Column(db.Enum(TicketStatus), default=TicketStatus.New)
+    tenant_id = db.Column(db.Integer, db.ForeignKey("tenants.id"), nullable=False)
+    author_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    status = db.Column(db.Enum(TicketStatus), default=TicketStatus.New, nullable=False)
     urgency = db.Column(db.String(12))
 
     notes = db.relationship(
@@ -37,7 +37,7 @@ class TicketModel(BaseModel):
             "id": self.id,
             "issue": self.issue,
             "tenant": "{} {}".format(self.tenant.firstName, self.tenant.lastName),
-            "creator_id": self.creator_id,
+            "author_id": self.author_id,
             "tenant_id": self.tenant_id,
             "assigned_staff": self.tenant.staff.json(),
             "sender": self.author.full_name(),

--- a/models/user.py
+++ b/models/user.py
@@ -52,7 +52,7 @@ class UserModel(BaseModel):
     authored_tickets = db.relationship(
         "TicketModel",
         backref="author",
-        primaryjoin=id == TicketModel.creator_id,
+        primaryjoin=id == TicketModel.author_id,
         collection_class=NobiruList,
     )
 

--- a/models/user.py
+++ b/models/user.py
@@ -48,16 +48,11 @@ class UserModel(BaseModel):
         backref=db.backref("user", lazy=True),
         collection_class=NobiruList,
     )
-    assigned_tickets = db.relationship(
-        "TicketModel",
-        backref="assignee",
-        primaryjoin=id == TicketModel.assignedUserID,
-        collection_class=NobiruList,
-    )
+
     authored_tickets = db.relationship(
         "TicketModel",
         backref="author",
-        primaryjoin=id == TicketModel.senderID,
+        primaryjoin=id == TicketModel.creator_id,
         collection_class=NobiruList,
     )
 

--- a/resources/tickets.py
+++ b/resources/tickets.py
@@ -26,9 +26,9 @@ class Ticket(Resource):
 class Tickets(Resource):
     @pm_level_required
     def get(self):
-        if request.args and request.args["tenantID"]:
+        if request.args and request.args["tenant_id"]:
             return {
-                "tickets": TenantModel.find(request.args["tenantID"]).tickets.json()
+                "tickets": TenantModel.find(request.args["tenant_id"]).tickets.json()
             }
         else:
             return {"tickets": TicketModel.query.json()}

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -22,7 +22,7 @@ class TicketSchema(ma.SQLAlchemyAutoSchema):
         if not TenantModel.query.get(value):
             raise ValidationError(f"{value} is not a valid tenant ID")
 
-    @validates("creator_id")
+    @validates("author_id")
     def validate_creator(self, value):
         if not UserModel.query.get(value):
             raise ValidationError(f"{value} is not a valid user ID")

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -1,7 +1,7 @@
 from ma import ma
 from models.tickets import TicketModel
 from models.tenant import TenantModel
-from models.user import UserModel, RoleEnum
+from models.user import UserModel
 from utils.time import time_format
 from marshmallow import fields, validates, ValidationError
 
@@ -12,25 +12,17 @@ class TicketSchema(ma.SQLAlchemyAutoSchema):
         include_fk = True
 
     tenant = fields.Nested("TenantSchema")
-    user = fields.Nested("UserSchema")
+    author = fields.Nested("UserSchema")
 
     created_at = fields.DateTime(time_format)
     updated_at = fields.DateTime(time_format)
 
-    @validates("tenantID")
+    @validates("tenant_id")
     def validate_tenant(self, value):
         if not TenantModel.query.get(value):
             raise ValidationError(f"{value} is not a valid tenant ID")
 
-    @validates("assignedUserID")
-    def validate_assigned_user(self, value):
-        user = UserModel.query.get(value)
-        if not user:
-            raise ValidationError(f"{value} is not a valid user ID")
-        if user.role != RoleEnum.STAFF:
-            raise ValidationError(f"{value} is not JOIN staff")
-
-    @validates("senderID")
-    def validate_sender(self, value):
+    @validates("creator_id")
+    def validate_creator(self, value):
         if not UserModel.query.get(value):
             raise ValidationError(f"{value} is not a valid user ID")

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -23,6 +23,6 @@ class TicketSchema(ma.SQLAlchemyAutoSchema):
             raise ValidationError(f"{value} is not a valid tenant ID")
 
     @validates("author_id")
-    def validate_creator(self, value):
+    def validate_author(self, value):
         if not UserModel.query.get(value):
             raise ValidationError(f"{value} is not a valid user ID")

--- a/tests/factory_fixtures/ticket.py
+++ b/tests/factory_fixtures/ticket.py
@@ -1,6 +1,7 @@
 import pytest
 from models.tickets import TicketModel
 from models.tickets import TicketStatus
+from schemas.ticket import TicketSchema
 
 
 @pytest.fixture
@@ -23,7 +24,10 @@ def create_ticket(faker, ticket_attributes, create_tenant, create_join_staff):
         if not issue:
             issue = faker.sentence()
         tenant = create_tenant()
-        ticket = TicketModel(**ticket_attributes(issue, tenant, create_join_staff()))
+        ticket = TicketModel.create(
+            schema=TicketSchema,
+            payload=ticket_attributes(issue, tenant, create_join_staff()),
+        )
         ticket.save_to_db()
         return ticket
 

--- a/tests/factory_fixtures/ticket.py
+++ b/tests/factory_fixtures/ticket.py
@@ -6,11 +6,11 @@ from schemas.ticket import TicketSchema
 
 @pytest.fixture
 def ticket_attributes(faker):
-    def _ticket_attributes(issue, tenant, creator):
+    def _ticket_attributes(issue, tenant, author):
         return {
             "issue": issue,
             "tenant_id": tenant.id,
-            "author_id": creator.id,
+            "author_id": author.id,
             "status": TicketStatus.New,
             "urgency": faker.random_element(("Low", "Medium", "High")),
         }

--- a/tests/factory_fixtures/ticket.py
+++ b/tests/factory_fixtures/ticket.py
@@ -9,7 +9,7 @@ def ticket_attributes(faker):
         return {
             "issue": issue,
             "tenant_id": tenant.id,
-            "creator_id": creator.id,
+            "author_id": creator.id,
             "status": TicketStatus.New,
             "urgency": faker.random_element(("Low", "Medium", "High")),
         }

--- a/tests/factory_fixtures/ticket.py
+++ b/tests/factory_fixtures/ticket.py
@@ -5,12 +5,11 @@ from models.tickets import TicketStatus
 
 @pytest.fixture
 def ticket_attributes(faker):
-    def _ticket_attributes(issue, tenant, assignedUser, sender):
+    def _ticket_attributes(issue, tenant, creator):
         return {
             "issue": issue,
-            "tenantID": tenant.id,
-            "assignedUserID": assignedUser.id,
-            "senderID": sender.id,
+            "tenant_id": tenant.id,
+            "creator_id": creator.id,
             "status": TicketStatus.New,
             "urgency": faker.random_element(("Low", "Medium", "High")),
         }
@@ -19,16 +18,12 @@ def ticket_attributes(faker):
 
 
 @pytest.fixture
-def create_ticket(
-    faker, ticket_attributes, create_tenant, create_admin_user, create_join_staff
-):
+def create_ticket(faker, ticket_attributes, create_tenant, create_join_staff):
     def _create_ticket(issue=None):
         if not issue:
             issue = faker.sentence()
         tenant = create_tenant()
-        ticket = TicketModel(
-            **ticket_attributes(issue, tenant, create_admin_user(), create_join_staff())
-        )
+        ticket = TicketModel(**ticket_attributes(issue, tenant, create_join_staff()))
         ticket.save_to_db()
         return ticket
 

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -18,11 +18,11 @@ def test_tickets_GET_all(client, test_database, auth_headers):
 
 
 def test_tickets_GET_byTenant(client, test_database, auth_headers):
-    response = client.get(f"{endpoint}?tenantID=1", headers=auth_headers["admin"])
+    response = client.get(f"{endpoint}?tenant_id=1", headers=auth_headers["admin"])
     assert is_valid(response, 200)
     assert len(response.json["tickets"]) == 2
-    assert response.json["tickets"][0]["tenantID"] == 1
-    assert response.json["tickets"][1]["tenantID"] == 1
+    assert response.json["tickets"][0]["tenant_id"] == 1
+    assert response.json["tickets"][1]["tenant_id"] == 1
 
 
 def test_tickets_GET_one(client, test_database, auth_headers):
@@ -31,11 +31,9 @@ def test_tickets_GET_one(client, test_database, auth_headers):
     assert response.json["id"] == 1
     assert response.json["issue"] == "The roof, the roof, the roof is on fire."
     assert response.json["tenant"] == "Renty McRenter"
-    assert response.json["senderID"] == 1
-    assert response.json["tenantID"] == 1
-    assert response.json["assignedUserID"] == 4
+    assert response.json["creator_id"] == 1
+    assert response.json["tenant_id"] == 1
     assert response.json["sender"] == "user1 tester"
-    assert response.json["assigned"] == "Mr. Sir"
     assert response.json["status"] == TicketStatus.In_Progress
     assert response.json["urgency"] == "Low"
     assert len(response.json["notes"]) == 2
@@ -53,12 +51,11 @@ def test_tickets_GET_one(client, test_database, auth_headers):
 
 def test_tickets_POST(client, auth_headers):
     newTicket = {
-        "senderID": 1,
-        "tenantID": 1,
+        "creator_id": 1,
+        "tenant_id": 1,
         "status": "New",
         "urgency": "low",
         "issue": "Lead paint issue",
-        "assignedUserID": 10,
     }
 
     response = client.post(endpoint, json=newTicket, headers=auth_headers["admin"])
@@ -69,10 +66,9 @@ def test_tickets_POST(client, auth_headers):
 
 def test_tickets_PUT(client, auth_headers):
     updatedTicket = {
-        "senderID": 2,
-        "tenantID": 2,
-        "assignedUserID": 10,
-        "status": "In_Progress",
+        "creator_id": 2,
+        "tenant_id": 2,
+        "status": "In Progress",
         "urgency": "high",
         "issue": "Leaky pipe",
     }
@@ -84,11 +80,9 @@ def test_tickets_PUT(client, auth_headers):
     assert is_valid(response, 200)
     assert response.json["issue"] == "Leaky pipe"
     assert response.json["tenant"] == "Soho Muless"
-    assert response.json["senderID"] == 2
-    assert response.json["tenantID"] == 2
-    assert response.json["assignedUserID"] == 10
+    assert response.json["creator_id"] == 2
+    assert response.json["tenant_id"] == 2
     assert response.json["sender"] == "user2 tester"
-    assert response.json["assigned"] == "Janice Joinstaff"
     assert response.json["status"] == TicketStatus.In_Progress
     assert response.json["urgency"] == "high"
 

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -68,7 +68,7 @@ def test_tickets_PUT(client, auth_headers):
     updatedTicket = {
         "creator_id": 2,
         "tenant_id": 2,
-        "status": "In Progress",
+        "status": "In_Progress",
         "urgency": "high",
         "issue": "Leaky pipe",
     }

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -31,7 +31,7 @@ def test_tickets_GET_one(client, test_database, auth_headers):
     assert response.json["id"] == 1
     assert response.json["issue"] == "The roof, the roof, the roof is on fire."
     assert response.json["tenant"] == "Renty McRenter"
-    assert response.json["creator_id"] == 1
+    assert response.json["author_id"] == 1
     assert response.json["tenant_id"] == 1
     assert response.json["sender"] == "user1 tester"
     assert response.json["status"] == TicketStatus.In_Progress
@@ -51,7 +51,7 @@ def test_tickets_GET_one(client, test_database, auth_headers):
 
 def test_tickets_POST(client, auth_headers):
     newTicket = {
-        "creator_id": 1,
+        "author_id": 1,
         "tenant_id": 1,
         "status": "New",
         "urgency": "low",
@@ -66,7 +66,7 @@ def test_tickets_POST(client, auth_headers):
 
 def test_tickets_PUT(client, auth_headers):
     updatedTicket = {
-        "creator_id": 2,
+        "author_id": 2,
         "tenant_id": 2,
         "status": "In_Progress",
         "urgency": "high",
@@ -80,7 +80,7 @@ def test_tickets_PUT(client, auth_headers):
     assert is_valid(response, 200)
     assert response.json["issue"] == "Leaky pipe"
     assert response.json["tenant"] == "Soho Muless"
-    assert response.json["creator_id"] == 2
+    assert response.json["author_id"] == 2
     assert response.json["tenant_id"] == 2
     assert response.json["sender"] == "user2 tester"
     assert response.json["status"] == TicketStatus.In_Progress

--- a/tests/schemas/test_note_schema.py
+++ b/tests/schemas/test_note_schema.py
@@ -7,7 +7,7 @@ class TestNotesSchemaSerialization:
     @pytest.mark.usefixtures("empty_test_db")
     def test_notes_serialization(self, create_note, create_ticket):
         ticket = create_ticket()
-        user = UserModel.query.filter_by(id=ticket.senderID).first()
+        user = UserModel.query.filter_by(id=ticket.creator_id).first()
         note = create_note(user, ticket)
 
         note_schema = NotesSchema()

--- a/tests/schemas/test_note_schema.py
+++ b/tests/schemas/test_note_schema.py
@@ -7,7 +7,7 @@ class TestNotesSchemaSerialization:
     @pytest.mark.usefixtures("empty_test_db")
     def test_notes_serialization(self, create_note, create_ticket):
         ticket = create_ticket()
-        user = UserModel.query.filter_by(id=ticket.creator_id).first()
+        user = UserModel.query.filter_by(id=ticket.author_id).first()
         note = create_note(user, ticket)
 
         note_schema = NotesSchema()

--- a/tests/schemas/test_ticket_schema.py
+++ b/tests/schemas/test_ticket_schema.py
@@ -1,28 +1,15 @@
+import pytest
 from schemas import TicketSchema
 
 
+@pytest.mark.usefixtures("empty_test_db")
 class TestTicketValidations:
-    def test_valid_payload(
-        self, empty_test_db, create_tenant, create_admin_user, create_join_staff
-    ):
+    def test_valid_payload(self, create_tenant, create_admin_user):
 
         valid_payload = {
-            "tenantID": create_tenant().id,
-            "assignedUserID": create_join_staff().id,
-            "senderID": create_admin_user().id,
+            "tenant_id": create_tenant().id,
+            "creator_id": create_admin_user().id,
         }
 
         no_validation_errors = {}
         assert no_validation_errors == TicketSchema().validate(valid_payload)
-
-    def test_assign_non_staff(
-        self, empty_test_db, create_tenant, create_admin_user, create_join_staff
-    ):
-        invalid_assigned_user = {
-            "tenantID": create_tenant().id,
-            "assignedUserID": create_admin_user().id,
-            "senderID": create_join_staff().id,
-        }
-
-        validation_errors = TicketSchema().validate(invalid_assigned_user)
-        assert "assignedUserID" in validation_errors

--- a/tests/schemas/test_ticket_schema.py
+++ b/tests/schemas/test_ticket_schema.py
@@ -8,7 +8,7 @@ class TestTicketValidations:
 
         valid_payload = {
             "tenant_id": create_tenant().id,
-            "creator_id": create_admin_user().id,
+            "author_id": create_admin_user().id,
         }
 
         no_validation_errors = {}

--- a/tests/unit/test_notes.py
+++ b/tests/unit/test_notes.py
@@ -17,7 +17,7 @@ class TestBaseNotesModel(BaseInterfaceTest):
 class TestNotesModel:
     def test_json(self, create_note, create_ticket):
         ticket = create_ticket()
-        user = UserModel.query.filter_by(id=ticket.creator_id).first()
+        user = UserModel.query.filter_by(id=ticket.author_id).first()
         note = create_note(user, ticket)
 
         assert note.json() == {

--- a/tests/unit/test_notes.py
+++ b/tests/unit/test_notes.py
@@ -17,7 +17,7 @@ class TestBaseNotesModel(BaseInterfaceTest):
 class TestNotesModel:
     def test_json(self, create_note, create_ticket):
         ticket = create_ticket()
-        user = UserModel.query.filter_by(id=ticket.senderID).first()
+        user = UserModel.query.filter_by(id=ticket.creator_id).first()
         note = create_note(user, ticket)
 
         assert note.json() == {

--- a/tests/unit/test_ticket.py
+++ b/tests/unit/test_ticket.py
@@ -12,19 +12,15 @@ class TestBaseTicketModel(BaseInterfaceTest):
     def test_validate_tenant(self):
         invalid_tenant = {"tenant_id": 666}
 
-        invalid_tenant_validation_error = {
-            "tenant_id": ["666 is not a valid tenant ID"]
-        }
-        assert invalid_tenant_validation_error == TicketSchema().validate(
-            invalid_tenant
-        )
+        invalid_tenant_validation_error = ["666 is not a valid tenant ID"]
 
-    def test_validate_creator(self):
-        invalid_creator = {"creator_id": 888}
+        validation_errors = TicketSchema().validate(invalid_tenant)
+        assert invalid_tenant_validation_error == validation_errors["tenant_id"]
 
-        invalid_creator_validation_error = {
-            "creator_id": ["888 is not a valid user ID"],
-        }
-        assert invalid_creator_validation_error == TicketSchema().validate(
-            invalid_creator
-        )
+    def test_validate_author(self):
+        invalid_creator = {"author_id": 888}
+
+        invalid_author_validation_error = ["888 is not a valid user ID"]
+
+        validation_errors = TicketSchema().validate(invalid_creator)
+        assert invalid_author_validation_error == validation_errors["author_id"]

--- a/tests/unit/test_ticket.py
+++ b/tests/unit/test_ticket.py
@@ -18,9 +18,9 @@ class TestBaseTicketModel(BaseInterfaceTest):
         assert invalid_tenant_validation_error == validation_errors["tenant_id"]
 
     def test_validate_author(self):
-        invalid_creator = {"author_id": 888}
+        invalid_author = {"author_id": 888}
 
         invalid_author_validation_error = ["888 is not a valid user ID"]
 
-        validation_errors = TicketSchema().validate(invalid_creator)
+        validation_errors = TicketSchema().validate(invalid_author)
         assert invalid_author_validation_error == validation_errors["author_id"]

--- a/tests/unit/test_ticket.py
+++ b/tests/unit/test_ticket.py
@@ -10,20 +10,21 @@ class TestBaseTicketModel(BaseInterfaceTest):
         self.schema = TicketSchema
 
     def test_validate_tenant(self):
-        invalid_tenant = {"tenantID": 666}
+        invalid_tenant = {"tenant_id": 666}
 
-        invalid_tenant_validation_error = {"tenantID": ["666 is not a valid tenant ID"]}
+        invalid_tenant_validation_error = {
+            "tenant_id": ["666 is not a valid tenant ID"]
+        }
         assert invalid_tenant_validation_error == TicketSchema().validate(
             invalid_tenant
         )
 
-    def test_validate_assigned_user_and_sender(self):
-        invalid_assigned_user_and_sender = {"assignedUserID": 777, "senderID": 888}
+    def test_validate_creator(self):
+        invalid_creator = {"creator_id": 888}
 
-        invalid_assigned_user_validation_error = {
-            "assignedUserID": ["777 is not a valid user ID"],
-            "senderID": ["888 is not a valid user ID"],
+        invalid_creator_validation_error = {
+            "creator_id": ["888 is not a valid user ID"],
         }
-        assert invalid_assigned_user_validation_error == TicketSchema().validate(
-            invalid_assigned_user_and_sender
+        assert invalid_creator_validation_error == TicketSchema().validate(
+            invalid_creator
         )


### PR DESCRIPTION
## Description

Updates the ticket model and schema.
Renames db fields for clarity and removes `noteslog` and `assignedUserID`.
The assigned users will now be the staff members who are assigned to the ticket's tenant.
Rather than returning a user id, the `json` method will now return a list json objects representing all assigned staff members.

@NickSchimek let me know if I should add some sort of validation to make sure the `creator_id` is the current user.  Also note that the ticket integration tests are pretty bad.  These should probably be addressed in another issue.


### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/614

_NOTE: DB needs to be re-seeded for this._
