### PR TITLE
Refactor tickets resource by using the update method for PUT requests

### DIFF
--- a/resources/tickets.py
+++ b/resources/tickets.py
@@ -3,6 +3,7 @@ from models.tickets import TicketModel
 from models.tenant import TenantModel
 from utils.authorizations import pm_level_required
 from flask import request
+from schemas.ticket import TicketSchema
 
 
 class Ticket(Resource):
@@ -26,29 +27,9 @@ class Ticket(Resource):
 
     @pm_level_required
     def put(self, id):
-        data = Ticket.parser.parse_args()
-        ticket = TicketModel.find(id)
-
-        if data.senderID:
-            ticket.senderID = data.senderID
-
-        if data.tenantID:
-            ticket.tenantID = data.tenantID
-
-        if data.assignedUserID:
-            ticket.assignedUserID = data.assignedUserID
-
-        if data.status:
-            ticket.status = data.status
-
-        if data.urgency:
-            ticket.urgency = data.urgency
-
-        if data.issue:
-            ticket.issue = data.issue
-
-        ticket.save_to_db()
-        return ticket.json()
+        return TicketModel.update(
+            schema=TicketSchema, id=id, payload=request.json
+        ).json()
 
 
 class Tickets(Resource):

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -84,8 +84,8 @@ def test_tickets_PUT(client, auth_headers):
     updatedTicket = {
         "senderID": 2,
         "tenantID": 2,
-        "assignedUserID": 3,
-        "status": "In Progress",
+        "assignedUserID": 10,
+        "status": "In_Progress",
         "urgency": "high",
         "issue": "Leaky pipe",
     }
@@ -99,9 +99,9 @@ def test_tickets_PUT(client, auth_headers):
     assert response.json["tenant"] == "Soho Muless"
     assert response.json["senderID"] == 2
     assert response.json["tenantID"] == 2
-    assert response.json["assignedUserID"] == 3
+    assert response.json["assignedUserID"] == 10
     assert response.json["sender"] == "user2 tester"
-    assert response.json["assigned"] == "user3 tester"
+    assert response.json["assigned"] == "Janice Joinstaff"
     assert response.json["status"] == TicketStatus.In_Progress
     assert response.json["urgency"] == "high"
 


### PR DESCRIPTION
## Description
Refactor tickets resource by using the update method for PUT requests, and uses the request json instead of the parser. Also updates tests.

### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/617
