### PR TITLE
628 refactor to use role level fixtures

### DIFF
--- a/tests/authorizations/test_email_authorization.py
+++ b/tests/authorizations/test_email_authorization.py
@@ -13,9 +13,7 @@ class TestEmailAuthorizations:
         assert is_valid(response, 401)
         assert response.json == {"message": "Missing authorization header"}
 
-    def test_all_roles_except_admin_are_denied_access(self, auth_headers):
+    def test_all_roles_except_admin_are_denied_access(self, pm_header):
         payload = {"user_id": 1, "subject": "Some email subject", "body": "Some body"}
-        for role, token in auth_headers.items():
-            if role != "admin":
-                response = self.client.post(self.endpoint, json=payload, headers=token)
-                assert is_valid(response, 401)
+        response = self.client.post(self.endpoint, json=payload, headers=pm_header)
+        assert is_valid(response, 401)

--- a/tests/authorizations/test_email_authorization.py
+++ b/tests/authorizations/test_email_authorization.py
@@ -13,27 +13,27 @@ class TestEmailAuthorizations:
         assert is_valid(response, 401)
         assert response.json == {"message": "Missing authorization header"}
 
-    def test_property_manager_is_denied_access(self, pm_header):
+    def test_property_manager_is_denied_access(self, pm_header, create_join_staff):
         payload = {
-            "user_id": 1,
+            "user_id": create_join_staff().id,
             "subject": "PM's email subject",
             "body": "I'm a property manager",
         }
         response = self.client.post(self.endpoint, json=payload, headers=pm_header)
         assert is_valid(response, 401)
 
-    # def test_admin_is_allowed_access(self, admin_header):
-    #     payload = {
-    #     "user_id": 2,
-    #     "subject": "Admin's email subject",
-    #     "body": "I'm an admin",
-    #     }
-    #     response = self.client.post(self.endpoint, json=payload, headers=admin_header)
-    #     assert is_valid(response, 200)
-
-    def test_staff_is_denied_access(self, staff_header):
+    def test_admin_is_allowed_access(self, admin_header, create_join_staff):
         payload = {
-            "user_id": 3,
+            "user_id": create_join_staff().id,
+            "subject": "Admin's email subject",
+            "body": "I'm an admin",
+        }
+        response = self.client.post(self.endpoint, json=payload, headers=admin_header)
+        assert is_valid(response, 200)
+
+    def test_staff_is_denied_access(self, staff_header, create_join_staff):
+        payload = {
+            "user_id": create_join_staff().id,
             "subject": "Staff's email subject",
             "body": "I'm staff",
         }

--- a/tests/authorizations/test_email_authorization.py
+++ b/tests/authorizations/test_email_authorization.py
@@ -13,7 +13,29 @@ class TestEmailAuthorizations:
         assert is_valid(response, 401)
         assert response.json == {"message": "Missing authorization header"}
 
-    def test_all_roles_except_admin_are_denied_access(self, pm_header):
-        payload = {"user_id": 1, "subject": "Some email subject", "body": "Some body"}
+    def test_property_manager_is_denied_access(self, pm_header):
+        payload = {
+            "user_id": 1,
+            "subject": "PM's email subject",
+            "body": "I'm a property manager",
+        }
         response = self.client.post(self.endpoint, json=payload, headers=pm_header)
+        assert is_valid(response, 401)
+
+    # def test_admin_is_allowed_access(self, admin_header):
+    #     payload = {
+    #     "user_id": 2,
+    #     "subject": "Admin's email subject",
+    #     "body": "I'm an admin",
+    #     }
+    #     response = self.client.post(self.endpoint, json=payload, headers=admin_header)
+    #     assert is_valid(response, 200)
+
+    def test_staff_is_denied_access(self, staff_header):
+        payload = {
+            "user_id": 3,
+            "subject": "Staff's email subject",
+            "body": "I'm staff",
+        }
+        response = self.client.post(self.endpoint, json=payload, headers=staff_header)
         assert is_valid(response, 401)


### PR DESCRIPTION
## Description
Refactor test_email_authorization.py to use role-level fixtures, not `auth_headers` fixture.

### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/628
