### PR TITLE
create note fixture no longer needs parameters

### DIFF
--- a/tests/factory_fixtures/notes.py
+++ b/tests/factory_fixtures/notes.py
@@ -1,5 +1,6 @@
 import pytest
 from models.notes import NotesModel
+from schemas.notes import NotesSchema
 
 
 @pytest.fixture
@@ -17,8 +18,9 @@ def create_note(faker, note_attributes, create_admin_user, create_ticket):
         user = user or create_admin_user()
         ticket = ticket or create_ticket()
 
-        note = NotesModel(**note_attributes(text, user, ticket))
-        note.save_to_db()
-        return note
+        return NotesModel.create(
+            schema=NotesSchema,
+            payload={"text": text, "user_id": user.id, "ticket_id": ticket.id},
+        )
 
     yield _create_note

--- a/tests/factory_fixtures/notes.py
+++ b/tests/factory_fixtures/notes.py
@@ -11,11 +11,13 @@ def note_attributes():
 
 
 @pytest.fixture
-def create_note(faker, note_attributes):
-    def _create_note(userid, ticketid, text=None):
-        if not text:
-            text = faker.paragraph()
-        note = NotesModel(**note_attributes(text, userid, ticketid))
+def create_note(faker, note_attributes, create_admin_user, create_ticket):
+    def _create_note(user=None, ticket=None, text=None):
+        text = text or faker.paragraph()
+        user = user or create_admin_user()
+        ticket = ticket or create_ticket()
+
+        note = NotesModel(**note_attributes(text, user, ticket))
         note.save_to_db()
         return note
 


### PR DESCRIPTION
## Description


Updated note factory fixture so that no attributes are required, though they still can be passed.

### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/639
