### PR TITLE
Move staff_tenant import to tenant model

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,10 +4,6 @@ from flask_jwt_extended import JWTManager
 from flask_cors import CORS
 from flask_mailman import Mail
 from models.user import UserModel
-
-# This should not be imported here, but for now we can force Flake8 to ignore the error
-# The "noqa" comment can be deleted when we figure out how to get around this.
-from models.staff_tenant_link import StaffTenantLink  # noqa: F401
 from models.revoked_tokens import RevokedTokensModel
 from resources.user import (
     UserRegister,

--- a/models/tenant.py
+++ b/models/tenant.py
@@ -4,6 +4,7 @@ from models.base_model import BaseModel
 from models.tickets import TicketModel
 from utils.time import Time
 from models.lease import LeaseModel
+from models.staff_tenant_link import StaffTenantLink
 
 
 class TenantModel(BaseModel):
@@ -18,7 +19,7 @@ class TenantModel(BaseModel):
     # relationships
     staff = db.relationship(
         "UserModel",
-        secondary="staff_tenant_links",
+        secondary=StaffTenantLink.tablename(),
         backref="tenants",
         collection_class=NobiruList,
     )


### PR DESCRIPTION
## Description

This is able to be done after having fixed the relationships for the
staff_tenant table in PR #231

Moved the staff_tenant import out of app.py and into the tenant model. This was previously unable to be done because of how the relationships were being defined.
