### PR TITLE
Refactor tickets integration tests

### DIFF
--- a/resources/tickets.py
+++ b/resources/tickets.py
@@ -1,7 +1,6 @@
 from db import db
 from flask_restful import Resource
 from models.tickets import TicketModel
-from models.tenant import TenantModel
 from utils.authorizations import pm_level_required
 from flask import request
 from schemas.ticket import TicketSchema
@@ -27,12 +26,10 @@ class Ticket(Resource):
 class Tickets(Resource):
     @pm_level_required
     def get(self):
-        if request.args and request.args["tenant_id"]:
-            return {
-                "tickets": TenantModel.find(request.args["tenant_id"]).tickets.json()
-            }
-        else:
-            return {"tickets": TicketModel.query.json()}
+        tickets = TicketModel.query
+        if "tenant_id" in request.args:
+            tickets = tickets.where(TicketModel.tenant_id == request.args["tenant_id"])
+        return {"tickets": tickets.json()}
 
     @pm_level_required
     def post(self):

--- a/tests/factory_fixtures/ticket.py
+++ b/tests/factory_fixtures/ticket.py
@@ -5,12 +5,12 @@ from schemas.ticket import TicketSchema
 
 
 @pytest.fixture
-def ticket_attributes(faker):
-    def _ticket_attributes(issue, tenant, author):
+def ticket_attributes(faker, create_tenant, create_join_staff):
+    def _ticket_attributes(issue=None, tenant=None, author=None):
         return {
-            "issue": issue,
-            "tenant_id": tenant.id,
-            "author_id": author.id,
+            "issue": issue or faker.sentence(),
+            "tenant_id": tenant.id if tenant else create_tenant().id,
+            "author_id": author.id if author else create_join_staff().id,
             "status": TicketStatus.New,
             "urgency": faker.random_element(("Low", "Medium", "High")),
         }

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -1,148 +1,124 @@
 import pytest
-from conftest import is_valid
 from db import db
-from models.tickets import TicketModel, TicketStatus
-
-endpoint = "/api/tickets"
-validID = 1
-invalidID = 777
+from models.tickets import TicketModel
+from schemas.ticket import TicketSchema
+from unittest.mock import patch
 
 
-def test_tickets_GET_all(client, test_database, auth_headers):
-    response = client.get(endpoint, headers=auth_headers["admin"])
-    assert is_valid(response, 200)
-    assert len(response.json["tickets"]) == 4
-    assert len(response.json["tickets"][0]["notes"]) == 2
-    assert len(response.json["tickets"][1]["notes"]) == 1
-    assert len(response.json["tickets"][2]["notes"]) == 1
-    assert len(response.json["tickets"][3]["notes"]) == 0
+@pytest.mark.usefixtures("client_class", "empty_test_db")
+class BaseConfig:
+    endpoint = "/api/tickets"
 
 
-def test_tickets_GET_byTenant(client, test_database, auth_headers):
-    response = client.get(f"{endpoint}?tenant_id=1", headers=auth_headers["admin"])
-    assert is_valid(response, 200)
-    assert len(response.json["tickets"]) == 2
-    assert response.json["tickets"][0]["tenant_id"] == 1
-    assert response.json["tickets"][1]["tenant_id"] == 1
+class TestTicketsGET(BaseConfig):
+    def test_tickets_get_all(self, valid_header, create_ticket):
+        ticket_1 = create_ticket()
+        ticket_2 = create_ticket()
+        response = self.client.get(self.endpoint, headers=valid_header)
+
+        assert response.status_code == 200
+        assert response.json == {"tickets": [ticket_1.json(), ticket_2.json()]}
+
+    def test_tickets_get_by_tenant(self, valid_header, create_ticket):
+        ticket_1 = create_ticket()
+        create_ticket()
+        create_ticket()
+
+        response = self.client.get(
+            f"{self.endpoint}?tenant_id={ticket_1.tenant.id}", headers=valid_header
+        )
+
+        assert response.status_code == 200
+        assert response.json == {"tickets": [ticket_1.json()]}
+
+    def test_tickets_get_one(self, valid_header, create_ticket):
+        ticket = create_ticket()
+        response = self.client.get(f"{self.endpoint}/{ticket.id}", headers=valid_header)
+
+        assert response.status_code == 200
+        assert response.json == ticket.json()
 
 
-def test_tickets_GET_one(client, test_database, auth_headers):
-    response = client.get(f"{endpoint}/{validID}", headers=auth_headers["admin"])
-    assert is_valid(response, 200)
-    assert response.json["id"] == 1
-    assert response.json["issue"] == "The roof, the roof, the roof is on fire."
-    assert response.json["tenant"] == "Renty McRenter"
-    assert response.json["author_id"] == 1
-    assert response.json["tenant_id"] == 1
-    assert response.json["sender"] == "user1 tester"
-    assert response.json["status"] == TicketStatus.In_Progress
-    assert response.json["urgency"] == "Low"
-    assert len(response.json["notes"]) == 2
-    assert response.json["notes"][0]["ticket_id"] == 1
-    assert response.json["notes"][0]["text"] == "Tenant has over 40 cats."
-    assert response.json["notes"][0]["user"] == "user2 tester"
-    assert response.json["notes"][1]["ticket_id"] == 1
-    assert response.json["notes"][1]["text"] == "Issue Resolved with phone call"
-    assert response.json["notes"][1]["user"] == "user3 tester"
+class TestTicketsPOST(BaseConfig):
+    def test_create_ticket(self, valid_header):
+        new_ticket = {
+            "author_id": 1,
+            "tenant_id": 1,
+            "status": "New",
+            "urgency": "low",
+            "issue": "Lead paint issue",
+        }
 
-    response = client.get(f"{endpoint}/{invalidID}", headers=auth_headers["admin"])
-    assert is_valid(response, 404)
-    assert response.json == {"message": "Ticket not found"}
+        with patch.object(TicketModel, "create") as mock_create:
+            response = self.client.post(
+                self.endpoint, json=new_ticket, headers=valid_header
+            )
+
+        mock_create.assert_called_once_with(schema=TicketSchema, payload=new_ticket)
+
+        assert response.status_code == 201
+        assert response.json == {"message": "Ticket successfully created"}
 
 
-def test_tickets_POST(client, auth_headers):
-    newTicket = {
-        "author_id": 1,
-        "tenant_id": 1,
-        "status": "New",
-        "urgency": "low",
-        "issue": "Lead paint issue",
-    }
+class TestTicketsPUT(BaseConfig):
+    def test_update_ticket(self, valid_header, create_ticket):
+        ticket = create_ticket()
+        with patch.object(TicketModel, "update", return_value=ticket) as mock_update:
+            response = self.client.put(
+                f"{self.endpoint}/{ticket.id}",
+                json={"hello": "world"},
+                headers=valid_header,
+            )
 
-    response = client.post(endpoint, json=newTicket, headers=auth_headers["admin"])
+        mock_update.assert_called_once_with(
+            schema=TicketSchema, id=ticket.id, payload={"hello": "world"}
+        )
 
-    assert is_valid(response, 201)
-    assert response.json == {"message": "Ticket successfully created"}
-
-
-def test_tickets_PUT(client, auth_headers):
-    updatedTicket = {
-        "author_id": 2,
-        "tenant_id": 2,
-        "status": "In_Progress",
-        "urgency": "high",
-        "issue": "Leaky pipe",
-    }
-
-    response = client.put(
-        f"{endpoint}/{validID}", json=updatedTicket, headers=auth_headers["admin"]
-    )
-
-    assert is_valid(response, 200)
-    assert response.json["issue"] == "Leaky pipe"
-    assert response.json["tenant"] == "Soho Muless"
-    assert response.json["author_id"] == 2
-    assert response.json["tenant_id"] == 2
-    assert response.json["sender"] == "user2 tester"
-    assert response.json["status"] == TicketStatus.In_Progress
-    assert response.json["urgency"] == "high"
-
-    # verify jwt only
-    response = client.put(
-        f"{endpoint}/{validID}", json=updatedTicket, headers=auth_headers["admin"]
-    )
-    assert is_valid(response, 200)
-
-    response = client.put(
-        f"{endpoint}/{invalidID}", json=updatedTicket, headers=auth_headers["admin"]
-    )
-    # NOT FOUND - Trying to update a non-existing ticket
-    assert is_valid(response, 404)
-    assert response.json == {"message": "Ticket not found"}
+        assert response.status_code == 200
+        assert response.json == ticket.json()
 
 
-def test_tickets_DELETE(client, auth_headers, create_ticket):
-    response = client.delete(f"{endpoint}/{validID}", headers=auth_headers["admin"])
-    assert is_valid(response, 200)
-    assert response.json == {"message": "Ticket removed from database"}
+class TestTicketsDELETE(BaseConfig):
+    def test_tickets_delete_one(self, valid_header):
+        with patch.object(TicketModel, "delete") as mock_delete:
+            response = self.client.delete(f"{self.endpoint}/1", headers=valid_header)
 
-    response = client.delete(f"{endpoint}/{validID}", headers=auth_headers["admin"])
-    # NOT FOUND - Trying to delete a non-existing ticket or an already deleted ticket
-    assert is_valid(response, 404)
-    assert response.json == {"message": "Ticket not found"}
+        mock_delete.assert_called_once_with(1)
+        assert response.status_code == 200
+        assert response.json == {"message": "Ticket removed from database"}
 
+    def test_tickets_delete_many(self, valid_header, create_ticket):
+        ticket_1 = create_ticket()
+        ticket_2 = create_ticket()
+        delete_ids = {"ids": [ticket_1.id, ticket_2.id]}
 
-def test_tickets_DELETE_list(client, auth_headers, create_ticket):
-    ticketsToDelete = [create_ticket().id, create_ticket().id]
-    deleteIds = {"ids": ticketsToDelete}
-    response = client.delete(endpoint, json=deleteIds, headers=auth_headers["pm"])
-    assert is_valid(response, 200)
-    assert response.json == {"message": "Tickets successfully deleted"}
+        response = self.client.delete(
+            self.endpoint, json=delete_ids, headers=valid_header
+        )
+        db.session.rollback()
 
-    nonExistentTicketId = 999
-    ticketsToDelete = [create_ticket().id, nonExistentTicketId]
-    deleteIds = {"ids": ticketsToDelete}
-    response = client.delete(endpoint, json=deleteIds, headers=auth_headers["pm"])
-    assert is_valid(response, 200)
-    assert response.json == {"message": "Tickets successfully deleted"}
+        assert response.status_code == 200
+        assert response.json == {"message": "Tickets successfully deleted"}
+        assert TicketModel.query.all() == []
 
-    missingIds = {"notIds": [5]}
-    response = client.delete(endpoint, json=missingIds, headers=auth_headers["pm"])
-    assert is_valid(response, 400)
-    assert response.json == {"message": "Ticket IDs missing in request"}
+    def test_delete_many_ignores_nonexistent_ids(self, valid_header, create_ticket):
+        nonExistentTicketId = 999
+        ticketsToDelete = [create_ticket().id, nonExistentTicketId]
+        deleteIds = {"ids": ticketsToDelete}
+        response = self.client.delete(
+            self.endpoint, json=deleteIds, headers=valid_header
+        )
 
+        assert response.status_code == 200
+        assert response.json == {"message": "Tickets successfully deleted"}
 
-def test_tickets_delete_many(client, empty_test_db, valid_header, create_ticket):
-    ticket_1 = create_ticket()
-    ticket_2 = create_ticket()
-    delete_ids = {"ids": [ticket_1.id, ticket_2.id]}
-
-    response = client.delete(endpoint, json=delete_ids, headers=valid_header)
-    db.session.rollback()
-
-    assert response.status_code == 200
-    assert response.json == {"message": "Tickets successfully deleted"}
-    assert TicketModel.query.all() == []
+    def test_delete_many_requires_ids_field(self, valid_header):
+        missingIds = {"notIds": [5]}
+        response = self.client.delete(
+            self.endpoint, json=missingIds, headers=valid_header
+        )
+        assert response.status_code == 400
+        assert response.json == {"message": "Ticket IDs missing in request"}
 
 
 @pytest.mark.usefixtures("empty_test_db")


### PR DESCRIPTION
## Description

Replaces `auth_headers` with `valid_header` and refactors all tests in the file.

All tests are now separated into appropriate classes, which inherit fixtures and endpoint from a base configuration class.
Methods are stubbed out where appropriate, but I couldn't figure out a nice way to test the delete action here using the patch, so those tests still hit the endpoint.

### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/597
