### PR TITLE
Create user subclasses

### DIFF
--- a/data/seedData.py
+++ b/data/seedData.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timedelta
 
 from models.user import UserModel, RoleEnum
+from models.users.admin import Admin
+from models.users.staff import Staff
+from models.users.property_manager import PropertyManager
 from models.property import PropertyModel
 from models.tenant import TenantModel
 from models.tickets import TicketModel, TicketStatus
@@ -16,7 +19,7 @@ def seedData():
     now = datetime.utcnow()
     future = now + timedelta(days=365)
 
-    user_1 = UserModel(
+    user_1 = Admin(
         email="user1@dwellingly.org",
         role=RoleEnum.ADMIN,
         firstName="user1",
@@ -26,7 +29,7 @@ def seedData():
         archived=False,
     )
     user_1.save_to_db()
-    user_2 = UserModel(
+    user_2 = Admin(
         email="user2@dwellingly.org",
         role=RoleEnum.ADMIN,
         firstName="user2",
@@ -36,7 +39,7 @@ def seedData():
         archived=False,
     )
     user_2.save_to_db()
-    user_3 = UserModel(
+    user_3 = Admin(
         email="user3@dwellingly.org",
         role=RoleEnum.ADMIN,
         firstName="user3",
@@ -46,7 +49,7 @@ def seedData():
         archived=False,
     )
     user_3.save_to_db()
-    user_mister_sir = UserModel(
+    user_mister_sir = PropertyManager(
         email="MisterSir@dwellingly.org",
         role=RoleEnum.PROPERTY_MANAGER,
         firstName="Mr.",
@@ -56,7 +59,7 @@ def seedData():
         archived=False,
     )
     user_mister_sir.save_to_db()
-    user_gray_pouponn = UserModel(
+    user_gray_pouponn = PropertyManager(
         email="GrayPouponn@dwellingly.org",
         role=RoleEnum.PROPERTY_MANAGER,
         firstName="Gray",
@@ -106,7 +109,7 @@ def seedData():
         },
         schema=UserRegisterSchema,
     )
-    user_janice_joinstaff = UserModel(
+    user_janice_joinstaff = Staff(
         email="janice@joinpdx.org",
         role=RoleEnum.STAFF,
         firstName="Janice",
@@ -116,7 +119,7 @@ def seedData():
         archived=False,
     )
     user_janice_joinstaff.save_to_db()
-    user_hector_chen = UserModel(
+    user_hector_chen = Staff(
         email="hector@joinpdx.org",
         role=RoleEnum.STAFF,
         firstName="Hector",
@@ -126,7 +129,7 @@ def seedData():
         archived=False,
     )
     user_hector_chen.save_to_db()
-    user_xander_dander = UserModel(
+    user_xander_dander = Staff(
         email="xander@joinpdx.org",
         role=RoleEnum.STAFF,
         firstName="Xander",

--- a/models/property.py
+++ b/models/property.py
@@ -24,14 +24,15 @@ class PropertyModel(BaseModel):
         cascade="all, delete-orphan",
         collection_class=NobiruList,
     )
+
     managers = db.relationship(
-        UserModel,
+        "PropertyManager",
         secondary=PropertyAssignment.tablename(),
-        backref="properties",
+        back_populates="properties",
         collection_class=NobiruList,
     )
 
-    def json(self, include_tenants=False):
+    def json(self, include_tenants=False, include_managers=True):
         property = {
             "id": self.id,
             "name": self.name,
@@ -40,12 +41,14 @@ class PropertyModel(BaseModel):
             "city": self.city,
             "state": self.state,
             "zipcode": self.zipcode,
-            "propertyManagers": self.managers.json(),
             "leases": self.leases.json(),
             "archived": self.archived,
         }
         if include_tenants:
             property["tenants"] = self.tenants()
+
+        if include_managers:
+            property["propertyManagers"] = self.managers.json()
 
         return property
 

--- a/models/tenant.py
+++ b/models/tenant.py
@@ -18,11 +18,11 @@ class TenantModel(BaseModel):
 
     # relationships
     staff = db.relationship(
-        "UserModel",
+        "Staff",
         secondary=StaffTenantLink.tablename(),
-        backref="tenants",
         collection_class=NobiruList,
     )
+
     leases = db.relationship(
         "LeaseModel",
         backref="tenant",
@@ -30,6 +30,7 @@ class TenantModel(BaseModel):
         cascade="all, delete-orphan",
         collection_class=NobiruList,
     )
+
     tickets = db.relationship(
         TicketModel, backref="tenant", lazy=True, collection_class=NobiruList
     )

--- a/models/user.py
+++ b/models/user.py
@@ -32,7 +32,10 @@ class RoleEnum(Enum):
 class UserModel(BaseModel):
     __tablename__ = "users"
 
+    __mapper_args__ = {"polymorphic_identity": "user", "polymorphic_on": "type"}
+
     id = db.Column(db.Integer, primary_key=True)
+    type = db.Column(db.String())
     email = db.Column(db.String(100), unique=True, nullable=False)
     role = db.Column(db.Enum(RoleEnum), default=None)
     firstName = db.Column(db.String(100), nullable=False)

--- a/models/user.py
+++ b/models/user.py
@@ -95,7 +95,7 @@ class UserModel(BaseModel):
         return bcrypt.checkpw(bytes(plaintext_password, "utf-8"), self.hash_digest)
 
     def json(self):
-        return {
+        base_json = {
             "id": self.id,
             "firstName": self.firstName,
             "lastName": self.lastName,
@@ -107,6 +107,10 @@ class UserModel(BaseModel):
             "created_at": Time.format_date(self.created_at),
             "updated_at": Time.format_date(self.updated_at),
         }
+        return {**base_json, **self.serialize()}
+
+    def serialize(self):
+        return {}
 
     def widgetJson(self, propertyName, date):
         return {

--- a/models/users/admin.py
+++ b/models/users/admin.py
@@ -1,0 +1,5 @@
+from models.user import UserModel
+
+
+class Admin(UserModel):
+    __mapper_args__ = {"polymorphic_identity": "admin"}

--- a/models/users/property_manager.py
+++ b/models/users/property_manager.py
@@ -1,0 +1,8 @@
+from db import db
+from models.user import UserModel
+from models.property_assignment import PropertyAssignment
+from nobiru.nobiru_list import NobiruList
+
+
+class PropertyManager(UserModel):
+    __mapper_args__ = {"polymorphic_identity": "property_manager"}

--- a/models/users/property_manager.py
+++ b/models/users/property_manager.py
@@ -6,3 +6,13 @@ from nobiru.nobiru_list import NobiruList
 
 class PropertyManager(UserModel):
     __mapper_args__ = {"polymorphic_identity": "property_manager"}
+
+    properties = db.relationship(
+        "PropertyModel",
+        secondary=PropertyAssignment.tablename(),
+        collection_class=NobiruList,
+        viewonly=True,
+    )
+
+    def serialize(self):
+        return {"properties": self.properties.json(include_managers=False)}

--- a/models/users/staff.py
+++ b/models/users/staff.py
@@ -1,0 +1,8 @@
+from db import db
+from models.user import UserModel
+from models.staff_tenant_link import StaffTenantLink
+from nobiru.nobiru_list import NobiruList
+
+
+class Staff(UserModel):
+    __mapper_args__ = {"polymorphic_identity": "staff"}

--- a/models/users/staff.py
+++ b/models/users/staff.py
@@ -6,3 +6,10 @@ from nobiru.nobiru_list import NobiruList
 
 class Staff(UserModel):
     __mapper_args__ = {"polymorphic_identity": "staff"}
+
+    tenants = db.relationship(
+        "TenantModel",
+        secondary=StaffTenantLink.tablename(),
+        collection_class=NobiruList,
+        viewonly=True,
+    )

--- a/nobiru/nobiru.py
+++ b/nobiru/nobiru.py
@@ -1,4 +1,4 @@
 class Nobiru:
     @staticmethod
-    def json(collection):
-        return [object.json() for object in collection]
+    def json(collection, **kwargs):
+        return [object.json(**kwargs) for object in collection]

--- a/nobiru/nobiru_list.py
+++ b/nobiru/nobiru_list.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm.collections import collection
 
 
 class NobiruList(InstrumentedList):
-    def json(self):
-        return Nobiru.json(self)
+    def json(self, **kwargs):
+        return Nobiru.json(self, **kwargs)
 
     @collection.remover
     def delete(self, entity):

--- a/resources/user.py
+++ b/resources/user.py
@@ -89,6 +89,7 @@ class User(Resource):
 
         if data["role"]:
             user.role = RoleEnum(data["role"])
+            user.type = RoleEnum(data["role"]).name.lower()
         if data["firstName"] is not None:
             user.firstName = data["firstName"]
         if data["lastName"] is not None:

--- a/resources/user.py
+++ b/resources/user.py
@@ -1,7 +1,6 @@
 from flask_restful import Resource, reqparse
 from flask import request
 from schemas import UserRegisterSchema
-from schemas import UserSchema
 from models.property import PropertyModel
 from utils.authorizations import admin_required, admin, pm_level_required
 from models.user import UserModel, RoleEnum
@@ -35,10 +34,7 @@ class UserRegister(Resource):
 class User(Resource):
     @admin_required
     def get(self, user_id):
-        user = UserModel.find(user_id)
-        user_info = UserSchema().dump(user)
-
-        return user_info, 200
+        return UserModel.find(user_id).json()
 
     @pm_level_required
     def patch(self, user_id):

--- a/schemas/property.py
+++ b/schemas/property.py
@@ -1,6 +1,6 @@
 from ma import ma
 from models.property import PropertyModel
-from models.user import UserModel
+from models.users.property_manager import PropertyManager
 from schemas.property_assignment import PropertyAssignSchema
 from marshmallow import fields, validates, ValidationError, post_load
 from utils.time import time_format
@@ -38,7 +38,7 @@ class PropertySchema(ma.SQLAlchemyAutoSchema):
     def make_property_attributes(self, data, **kwargs):
         if "propertyManagerIDs" in data:
             data["managers"] = [
-                UserModel.find(manager) for manager in data["propertyManagerIDs"]
+                PropertyManager.find(id) for id in data["propertyManagerIDs"]
             ]
             del data["propertyManagerIDs"]
         return data

--- a/schemas/tenant.py
+++ b/schemas/tenant.py
@@ -1,6 +1,6 @@
 from ma import ma
 from models.tenant import TenantModel
-from models.user import UserModel
+from models.users.staff import Staff
 from marshmallow import fields, validate, validates, post_load
 from utils.time import time_format
 from schemas.staff_tenants import StaffTenantSchema
@@ -42,6 +42,6 @@ class TenantSchema(ma.SQLAlchemyAutoSchema):
     @post_load
     def make_tenant_attributes(self, data, **kwargs):
         if "staffIDs" in data:
-            data["staff"] = [UserModel.find(staff) for staff in data["staffIDs"]]
+            data["staff"] = [Staff.find(id) for id in data["staffIDs"]]
             del data["staffIDs"]
         return data

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -11,9 +11,6 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
     created_at = fields.DateTime(time_format)
     updated_at = fields.DateTime(time_format)
 
-    properties = fields.Method("serialize_props", dump_only=True)
-    tenants = fields.Method("serialize_tenants", dump_only=True)
-
     role = fields.Method("get_role_value", deserialize="load_role_enum")
 
     @validates("email")
@@ -29,12 +26,6 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
             raise ValidationError("Invalid role")
         else:
             return RoleEnum(value)
-
-    def serialize_tenants(self, obj):
-        return [lease.tenant.json() for prop in obj.properties for lease in prop.leases]
-
-    def serialize_props(self, obj):
-        return [prop.json() for prop in obj.properties]
 
 
 class UserRegisterSchema(UserSchema):

--- a/tests/factory_fixtures/user.py
+++ b/tests/factory_fixtures/user.py
@@ -1,5 +1,8 @@
 import pytest
 from models.user import UserModel, RoleEnum
+from models.users.admin import Admin
+from models.users.staff import Staff
+from models.users.property_manager import PropertyManager
 
 
 @pytest.fixture
@@ -21,7 +24,7 @@ def user_attributes(faker):
 @pytest.fixture
 def create_admin_user(user_attributes):
     def _create_admin_user(firstName=None, lastName=None):
-        admin = UserModel(
+        admin = Admin(
             **user_attributes(
                 role=RoleEnum.ADMIN,
                 firstName=firstName,
@@ -37,7 +40,7 @@ def create_admin_user(user_attributes):
 @pytest.fixture
 def create_join_staff(user_attributes):
     def _create_join_staff():
-        staff = UserModel(**user_attributes(role=RoleEnum.STAFF))
+        staff = Staff(**user_attributes(role=RoleEnum.STAFF))
         staff.save_to_db()
         return staff
 
@@ -47,7 +50,7 @@ def create_join_staff(user_attributes):
 @pytest.fixture
 def create_property_manager(user_attributes):
     def _create_property_manager():
-        pm = UserModel(**user_attributes(role=RoleEnum.PROPERTY_MANAGER))
+        pm = PropertyManager(**user_attributes(role=RoleEnum.PROPERTY_MANAGER))
         pm.save_to_db()
         return pm
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import patch
 from models.user import UserModel
+from models.users.admin import Admin
 from schemas import UserRegisterSchema
 from tests.schemas.test_user_schema import user_register_valid_payload
 from conftest import is_valid
@@ -171,6 +172,16 @@ def test_get_user(client, empty_test_db, valid_header, new_user):
         f"api/user?r={unknown_role}", headers=valid_header
     )
     assert is_valid(unknown_user_response, 400)
+
+
+@pytest.mark.usefixtures("client_class", "empty_test_db")
+class TestUser:
+    def test_role_update(self, valid_header, create_unauthorized_user):
+        id = create_unauthorized_user().id
+        payload = {"role": RoleEnum.ADMIN.value}
+        self.client.patch(f"api/user/{id}", json=payload, headers=valid_header)
+
+        assert Admin.find(id).role == RoleEnum.ADMIN
 
 
 @pytest.mark.usefixtures("client_class", "empty_test_db")

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -50,38 +50,12 @@ def test_get_user_by_id(client, empty_test_db, create_admin_user, valid_header):
     assert responseBadUserId.json == {"message": "User not found"}
 
 
-def test_get_pm_by_id(
-    client,
-    empty_test_db,
-    create_property_manager,
-    create_property,
-    create_lease,
-    valid_header,
-):
+def test_get_pm_by_id(client, empty_test_db, create_property_manager, valid_header):
     user = create_property_manager()
-    prop = create_property(manager_ids=[user.id])
-    lease_1 = create_lease(property=prop)
-    lease_2 = create_lease(property=prop)
-
     response = client.get(f"/api/user/{user.id}", headers=valid_header)
 
-    property_list = response.json["properties"]
-    tenants_list = response.json["tenants"]
-
-    """
-    The get user by id route returns a successful response code
-    when the queried user is a property manager
-    """
     assert response.status_code == 200
-
-    """The PM's properties are returned as a list of JSON objects"""
-    assert property_list == [prop.json()]
-
-    """
-    Tenants are retreived through the leases on each
-    property and returned as a list of JSON objects
-    """
-    assert tenants_list == [lease_1.tenant.json(), lease_2.tenant.json()]
+    assert response.json == user.json()
 
 
 def test_user_roles(client, test_database, valid_header):

--- a/tests/schemas/test_property_schema.py
+++ b/tests/schemas/test_property_schema.py
@@ -1,5 +1,7 @@
 import pytest
+from db import db
 from schemas import PropertySchema
+from models.property import PropertyModel
 
 
 @pytest.mark.usefixtures("empty_test_db")
@@ -74,21 +76,25 @@ class TestPostLoadDeserialization:
         pm_2 = create_property_manager()
         property_attrs = property_attributes(manager_ids=[pm_1.id, pm_2.id])
 
-        prop = PropertySchema().load(property_attrs)
+        prop = PropertyModel.create(schema=PropertySchema, payload=property_attrs)
+        db.session.rollback()
 
         assert prop
-        assert prop["managers"] == [pm_1, pm_2]
+        assert prop.managers == [pm_1, pm_2]
 
     def test_manager_update(self, create_property, create_property_manager):
-        prop = create_property()
+        property = create_property()
         pm_2 = create_property_manager()
         pm_3 = create_property_manager()
         payload = {"propertyManagerIDs": [pm_2.id, pm_3.id]}
-        context = {"name": prop.name}
+        context = {"name": property.name}
 
-        updated_prop = PropertySchema(context=context).load(payload, partial=True)
+        PropertyModel.update(
+            schema=PropertySchema, context=context, id=property.id, payload=payload
+        )
+        db.session.rollback()
 
-        assert updated_prop["managers"] == [pm_2, pm_3]
+        assert property.managers == [pm_2, pm_3]
 
     def test_property_update_without_managers(self, create_property):
         prop = create_property()

--- a/tests/schemas/test_user_schema.py
+++ b/tests/schemas/test_user_schema.py
@@ -1,4 +1,3 @@
-import pytest
 from schemas.user import UserSchema, UserRegisterSchema
 from models.user import RoleEnum
 
@@ -79,27 +78,3 @@ class TestUserRegisterSchemaValidations:
         validation_errors = UserRegisterSchema().validate({})
 
         assert "password" in validation_errors
-
-
-@pytest.mark.usefixtures("empty_test_db")
-class TestPropertyManagerSerialization:
-    def test_property_manager_serialization(
-        self, create_property_manager, create_lease, create_property, create_tenant
-    ):
-        pm = create_property_manager()
-        property1 = create_property(manager_ids=[pm.id])
-        property2 = create_property(manager_ids=[pm.id])
-        tenant1 = create_tenant()
-        tenant2 = create_tenant()
-        create_lease(property=property1, tenant=tenant1)
-        create_lease(property=property2, tenant=tenant2)
-
-        json_output = UserSchema().dump(pm)
-        assert json_output["tenants"] == [tenant1.json(), tenant2.json()]
-        assert json_output["properties"] == [property1.json(), property2.json()]
-
-    def test_user_serialization(self, create_join_staff):
-        user = create_join_staff()
-        json_output = UserSchema().dump(user)
-        assert json_output["tenants"] == []
-        assert json_output["properties"] == []

--- a/tests/unit/users/test_property_manager.py
+++ b/tests/unit/users/test_property_manager.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.usefixtures("empty_test_db")
+class TestSerialize:
+    def test_serialize(self, create_property_manager):
+        property_manager = create_property_manager()
+        assert property_manager.serialize() == {"properties": []}


### PR DESCRIPTION
## Description

We have 3 different types of users and depending on the type we need to
serialize differently, and assign relationships differently. This
construct will allow all our users to still behave like a user, but
we will be able to define different methods, relationships and serializations for
each type of user.

We'll end up removing the roles altogether as the current types can replace them. We may need roles in the future, but until then we might as well remove code that is no longer needed. We'll accomplish this in future PR's once the the frontend has made necessary changes. For example: We have multiple endpoints that handle roles (not needed) that the frontend depends (also not needed) these are not needed regardless if we keep roles or not.

So if your in the shell
```python
>>> admin = Admin.query.all()[0]
>>> admin.id
1
>>> user = UserModel.find(1)
>>> user.id
1

>>> admin
<'Admin' {'_sa_instance_state': <sqlalchemy.orm.state.InstanceState object at 0x10b357160>, 'created_at': datetime.datetime(2021, 6, 7, 17, 16, 34, 355652), 'updated_at': datetime.datetime(2021, 6, 7, 17, 16, 34, 355658), 'type': 'admin', 'role': <RoleEnum.ADMIN: 4>, 'lastName': 'tester', 'hash_digest': b'$2b$12$2Jv4P0B1.LlWp7.crOgI/OaTU8dZRr7942eVjxGW77Uy3vWNCM9uq', 'archived': False, 'id': 1, 'email': 'user1@dwellingly.org', 'firstName': 'user1', 'phone': '555-555-5555', 'password': None, 'lastActive': datetime.datetime(2021, 6, 7, 17, 16, 34, 355660)}>
>>> user
<'Admin' {'_sa_instance_state': <sqlalchemy.orm.state.InstanceState object at 0x10b357160>, 'created_at': datetime.datetime(2021, 6, 7, 17, 16, 34, 355652), 'updated_at': datetime.datetime(2021, 6, 7, 17, 16, 34, 355658), 'type': 'admin', 'role': <RoleEnum.ADMIN: 4>, 'lastName': 'tester', 'hash_digest': b'$2b$12$2Jv4P0B1.LlWp7.crOgI/OaTU8dZRr7942eVjxGW77Uy3vWNCM9uq', 'archived': False, 'id': 1, 'email': 'user1@dwellingly.org', 'firstName': 'user1', 'phone': '555-555-5555', 'password': None, 'lastActive': datetime.datetime(2021, 6, 7, 17, 16, 34, 355660)}>

>>> staff = Staff.query.all()[0]
>>> staff
<'Staff' {'_sa_instance_state': <sqlalchemy.orm.state.InstanceState object at 0x10b36a3a0>, 'created_at': datetime.datetime(2021, 6, 7, 17, 16, 38, 879350), 'updated_at': datetime.datetime(2021, 6, 7, 17, 16, 38, 879355), 'type': 'staff', 'role': <RoleEnum.STAFF: 3>, 'lastName': 'Joinstaff', 'hash_digest': b'$2b$12$FRLq8JULJ4CuT36wIwUoQ.4IULYcQqLXPvVEmzqOfZ8zEoFCKNHT6', 'archived': False, 'id': 10, 'email': 'janice@joinpdx.org', 'firstName': 'Janice', 'phone': '555-555-5555', 'password': None, 'lastActive': datetime.datetime(2021, 6, 7, 17, 16, 38, 879357)}>

>>> staff.tenants
[<'TenantModel' {'_sa_instance_state': <sqlalchemy.orm.state.InstanceState object at 0x10b3952e0>, 'updated_at': datetime.datetime(2021, 6, 7, 17, 16, 39, 910715), 'firstName': 'Renty', 'phone': '800-RENT-ALOT', 'created_at': datetime.datetime(2021, 6, 7, 17, 16, 39, 910711), 'id': 1, 'lastName': 'McRenter', 'archived': False}>]
>>> admin.tenants
Traceback (most recent call last):
  File "<console>", line 1, in <module>
AttributeError: 'Admin' object has no attribute 'tenants'
```

The user and admin variable contain the same objects.
the admin does not have tenants
the staff does have tenants

PropertyManager has properties. Admin and Staff do not