### PR TITLE
updates ticket schema to include note

### DIFF
--- a/schemas/notes.py
+++ b/schemas/notes.py
@@ -1,10 +1,16 @@
+from ma import ma
 from models.user import UserModel
 from models.tickets import TicketModel
+from models.notes import NotesModel
 from utils.time import time_format
-from marshmallow import fields, Schema, validates, ValidationError
+from marshmallow import fields, validates, ValidationError, post_load, EXCLUDE
 
 
-class NotesSchema(Schema):
+class NotesSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = NotesModel
+        unknown = EXCLUDE
+
     id = fields.Integer()
     text = fields.Str()
     user_id = fields.Integer(required=True)
@@ -28,3 +34,7 @@ class NotesSchema(Schema):
     def validates_existing_ticket(self, value):
         if not TicketModel.query.get(value):
             raise ValidationError(f"{value} is not a valid Ticket ID")
+
+    @post_load
+    def make_notes(self, data, **kwargs):
+        return NotesModel(**data)

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -2,6 +2,7 @@ from ma import ma
 from models.tickets import TicketModel
 from models.tenant import TenantModel
 from models.user import UserModel
+from models.notes import NotesModel
 from utils.time import time_format
 from marshmallow import fields, validates, ValidationError
 
@@ -13,7 +14,7 @@ class TicketSchema(ma.SQLAlchemyAutoSchema):
 
     tenant = fields.Nested("TenantSchema")
     author = fields.Nested("UserSchema")
-    note = fields.Nested("NotesSchema", required=False)
+    notes = fields.Nested("NotesSchema")
 
     created_at = fields.DateTime(time_format)
     updated_at = fields.DateTime(time_format)
@@ -27,3 +28,8 @@ class TicketSchema(ma.SQLAlchemyAutoSchema):
     def validate_author(self, value):
         if not UserModel.query.get(value):
             raise ValidationError(f"{value} is not a valid user ID")
+
+    @validates("notes")
+    def validate_note(self, value):
+        if not NotesModel.query.get(value):
+            raise ValidationError(f"{value} is not a valid note")

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -13,6 +13,7 @@ class TicketSchema(ma.SQLAlchemyAutoSchema):
 
     tenant = fields.Nested("TenantSchema")
     author = fields.Nested("UserSchema")
+    note = fields.Nested("NotesSchema", required=False)
 
     created_at = fields.DateTime(time_format)
     updated_at = fields.DateTime(time_format)

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -64,6 +64,21 @@ def test_tickets_POST(client, auth_headers):
     assert response.json == {"message": "Ticket successfully created"}
 
 
+def test_tickets_with_note_POST(client, auth_headers):
+    newTicket = {
+        "author_id": 1,
+        "tenant_id": 1,
+        "status": "New",
+        "urgency": "low",
+        "issue": "Lead paint issue",
+        "notes": {"text": "note text", "user_id": 1, "ticket_id": 1},
+    }
+
+    response = client.post(endpoint, json=newTicket, headers=auth_headers["admin"])
+    assert is_valid(response, 201)
+    assert response.json == {"message": "Ticket successfully created"}
+
+
 def test_tickets_PUT(client, auth_headers):
     updatedTicket = {
         "author_id": 2,

--- a/tests/schemas/test_ticket_schema.py
+++ b/tests/schemas/test_ticket_schema.py
@@ -22,10 +22,10 @@ class TestTicketValidations:
         valid_payload = {
             "tenant_id": create_tenant().id,
             "author_id": author_id,
-            "note": {**create_note().json(), "user_id": author_id},
+            "notes": {**create_note().json(), "user_id": author_id},
         }
 
-        del valid_payload["note"]["user"]
+        del valid_payload["notes"]["user"]
 
         no_validation_errors = {}
         assert no_validation_errors == TicketSchema().validate(valid_payload)

--- a/tests/schemas/test_ticket_schema.py
+++ b/tests/schemas/test_ticket_schema.py
@@ -4,12 +4,28 @@ from schemas import TicketSchema
 
 @pytest.mark.usefixtures("empty_test_db")
 class TestTicketValidations:
-    def test_valid_payload(self, create_tenant, create_admin_user):
+    def test_valid_payload_without_note(self, create_tenant, create_admin_user):
 
         valid_payload = {
             "tenant_id": create_tenant().id,
             "author_id": create_admin_user().id,
         }
+
+        no_validation_errors = {}
+        assert no_validation_errors == TicketSchema().validate(valid_payload)
+
+    def test_valid_payload_with_note(
+        self, create_tenant, create_admin_user, create_note
+    ):
+
+        author_id = create_admin_user().id
+        valid_payload = {
+            "tenant_id": create_tenant().id,
+            "author_id": author_id,
+            "note": {**create_note().json(), "user_id": author_id},
+        }
+
+        del valid_payload["note"]["user"]
 
         no_validation_errors = {}
         assert no_validation_errors == TicketSchema().validate(valid_payload)


### PR DESCRIPTION
## Description
This adds a Note field to the Ticket schema, and includes testing.  

I did it without changing the Notes schema, with requires a user_id field and rejects a user field.  I had to do some manipulation to the Note values because of this. 

Let me know if I should increase the scope of this PR and alter the Notes schema as well.

### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/620
