### PR TITLE
Ignore shelltools unused import warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@ max-line-length = 80
 select = C,E,F,W,B,B950
 ignore = E203,E501,W503
 exclude = __init__.py
+per-file-ignores = shelltools.py:F401


### PR DESCRIPTION
## Description
Whoops I inadvertently pushed straight to development branch and then of course flake 8 failed.

This ignores flake8 unused import warnings for the shelltools file.

This file is used to load all models in the flask shell.

For example: In the flask shell whenever you want to work with a model you have to import it. Which can be a pain to do every time for every model you want to use.
```python
>>> UserModel
Traceback (most recent call last):
  File "<console>", line 1, in <module>
NameError: name 'UserModel' is not defined
```

Simply import shelltools and all models get loaded.
```python
>>> from shelltools import *
>>> UserModel
<class 'models.user.UserModel'>
```

Maybe there is a way to auto load this when shell starts, but I'm happy with this for now.

And I've disabled my push access locally so this wont happen again :-) 
`git config branch.development.pushRemote no_push`