### PR TITLE
629 refactor test_emergency_contact_authorization to no auth headers

### DIFF
--- a/tests/authorizations/test_emergency_contact_authorization.py
+++ b/tests/authorizations/test_emergency_contact_authorization.py
@@ -7,10 +7,7 @@ class TestEmergenyContactsAuthorizations:
     def setup(self):
         self.endpoint = "/api/emergencycontacts"
 
-    def test_emergency_contacts_POST(self, auth_headers):
-        endpoint = "/api/emergencycontacts"
-
-        newContact = {
+        self.newContact = {
             "name": "Narcotics Anonymous",
             "description": "Cool description",
             "contact_numbers": [
@@ -19,23 +16,44 @@ class TestEmergenyContactsAuthorizations:
             ],
         }
 
-        response = self.client.post(
-            endpoint, json=newContact, headers=auth_headers["pm"]
-        )
-        assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
+        self.user_id = 1
 
-        response = self.client.post(endpoint, json=newContact)
-        assert is_valid(response, 401)  # UNAUTHORIZED - Missing Authorization Header
+    def test_auth_header_is_required(self):
+        response = self.client.post(self.endpoint, json=self.newContact)
+
+        assert is_valid(response, 401)
         assert response.json == {"message": "Missing authorization header"}
 
-    def test_emergency_contacts_DELETE(self, auth_headers):
-        endpoint = "/api/emergencycontacts"
-
-        id = 1
-
-        response = self.client.delete(f"{endpoint}/{id}")
-        assert is_valid(response, 401)  # UNAUTHORIZED - Missing Authorization Header
+        response = self.client.delete(f"{self.endpoint}/{self.user_id}")
+        assert is_valid(response, 401)
         assert response.json == {"message": "Missing authorization header"}
 
-        response = self.client.delete(f"{endpoint}/{id}", headers=auth_headers["pm"])
+
+    def test_prop_manager_denied_emerg_contacts_POST(self, pm_header):
+        response = self.client.post(self.endpoint, json = self.newContact, headers=pm_header)
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
+
+
+    def test_prop_manager_denied_emerg_contacts_DELETE(self, pm_header):
+        response = self.client.delete(f"{self.endpoint}/{self.user_id}", headers=pm_header)
+        assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
+
+
+    def test_staff_denied_emerg_contacts_POST(self, staff_header):
+        response = self.client.post(self.endpoint, json=self.newContact, headers=staff_header)
+        assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
+
+
+    def test_staff_denied_emerg_contacts_DELETE(self, staff_header):
+        response = self.client.delete(f"{self.endpoint}/{self.user_id}", headers=staff_header)
+        assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
+
+
+    def test_admin_allowed_emerg_contacts_POST(self, admin_header):
+        response = self.client.post(self.endpoint, json=self.newContact, headers=admin_header)
+        assert is_valid(response, 201)
+
+
+    def test_admin_allowed_emerg_contacts_DELETE(self, admin_header, create_emergency_contact):
+        response = self.client.delete(f"{self.endpoint}/{create_emergency_contact().id}", headers=admin_header)
+        assert is_valid(response, 200)

--- a/tests/authorizations/test_emergency_contact_authorization.py
+++ b/tests/authorizations/test_emergency_contact_authorization.py
@@ -28,32 +28,40 @@ class TestEmergenyContactsAuthorizations:
         assert is_valid(response, 401)
         assert response.json == {"message": "Missing authorization header"}
 
-
     def test_prop_manager_denied_emerg_contacts_POST(self, pm_header):
-        response = self.client.post(self.endpoint, json = self.newContact, headers=pm_header)
+        response = self.client.post(
+            self.endpoint, json=self.newContact, headers=pm_header
+        )
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
-
 
     def test_prop_manager_denied_emerg_contacts_DELETE(self, pm_header):
-        response = self.client.delete(f"{self.endpoint}/{self.user_id}", headers=pm_header)
+        response = self.client.delete(
+            f"{self.endpoint}/{self.user_id}", headers=pm_header
+        )
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
-
 
     def test_staff_denied_emerg_contacts_POST(self, staff_header):
-        response = self.client.post(self.endpoint, json=self.newContact, headers=staff_header)
+        response = self.client.post(
+            self.endpoint, json=self.newContact, headers=staff_header
+        )
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
-
 
     def test_staff_denied_emerg_contacts_DELETE(self, staff_header):
-        response = self.client.delete(f"{self.endpoint}/{self.user_id}", headers=staff_header)
+        response = self.client.delete(
+            f"{self.endpoint}/{self.user_id}", headers=staff_header
+        )
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
-
     def test_admin_allowed_emerg_contacts_POST(self, admin_header):
-        response = self.client.post(self.endpoint, json=self.newContact, headers=admin_header)
+        response = self.client.post(
+            self.endpoint, json=self.newContact, headers=admin_header
+        )
         assert is_valid(response, 201)
 
-
-    def test_admin_allowed_emerg_contacts_DELETE(self, admin_header, create_emergency_contact):
-        response = self.client.delete(f"{self.endpoint}/{create_emergency_contact().id}", headers=admin_header)
+    def test_admin_allowed_emerg_contacts_DELETE(
+        self, admin_header, create_emergency_contact
+    ):
+        response = self.client.delete(
+            f"{self.endpoint}/{create_emergency_contact().id}", headers=admin_header
+        )
         assert is_valid(response, 200)


### PR DESCRIPTION
## Description
Refactor test_emergency_contact_authorization.py to use role-level fixtures, not auth_headers fixture.
### What issue is this solving?
Closes codeforpdx/dwellingly-app/issues/629
