### PR TITLE
Improvemen user model

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -57,7 +57,7 @@ class UserModel(BaseModel):
 
     @property
     def password(self):
-        return self._password
+        raise AttributeError('password field is not allowed to access')
 
     @password.setter
     def password(self, plaintext_password):
@@ -87,7 +87,7 @@ class UserModel(BaseModel):
             return None
 
     def check_pw(self, plaintext_password):
-        return bcrypt.checkpw(plaintext_password.encode("utf-8"), self.password)
+        return bcrypt.checkpw(plaintext_password.encode("utf-8"), self._password)
 
     def json(self):
         return {

--- a/models/user.py
+++ b/models/user.py
@@ -38,7 +38,6 @@ class UserModel(BaseModel):
     firstName = db.Column(db.String(100), nullable=False)
     lastName = db.Column(db.String(100), nullable=False)
     phone = db.Column(db.String(20), nullable=False)
-    # hash_digest = db.Column(db.LargeBinary(60))
     _password = db.Column("password", db.LargeBinary(60))
     archived = db.Column(db.Boolean, default=False, nullable=False)
     lastActive = db.Column(db.DateTime, default=datetime.utcnow)
@@ -88,7 +87,7 @@ class UserModel(BaseModel):
             return None
 
     def check_pw(self, plaintext_password):
-        return bcrypt.checkpw(bytes(plaintext_password, "utf-8"), self.password)
+        return bcrypt.checkpw(plaintext_password.encode("utf-8"), self.password)
 
     def json(self):
         return {

--- a/models/user.py
+++ b/models/user.py
@@ -57,7 +57,7 @@ class UserModel(BaseModel):
 
     @property
     def password(self):
-        raise AttributeError('password field is not allowed to access')
+        raise AttributeError("password field is not allowed to access")
 
     @password.setter
     def password(self, plaintext_password):

--- a/models/user.py
+++ b/models/user.py
@@ -39,7 +39,7 @@ class UserModel(BaseModel):
     lastName = db.Column(db.String(100), nullable=False)
     phone = db.Column(db.String(20), nullable=False)
     # hash_digest = db.Column(db.LargeBinary(60))
-    _password = db.Column('password', db.LargeBinary(60))
+    _password = db.Column("password", db.LargeBinary(60))
     archived = db.Column(db.Boolean, default=False, nullable=False)
     lastActive = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -63,7 +63,7 @@ class UserModel(BaseModel):
     @password.setter
     def password(self, plaintext_password):
         self._password = bcrypt.hashpw(
-            plaintext_password.encode('utf-8'),
+            plaintext_password.encode("utf-8"),
             bcrypt.gensalt(current_app.config["WORK_FACTOR"]),
         )
 
@@ -144,4 +144,3 @@ class UserModel(BaseModel):
 
     def full_name(self):
         return "{} {}".format(self.firstName, self.lastName)
-

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -15,7 +15,6 @@ class TestLease:
         with patch.object(LeaseModel, "find", return_value=lease) as mock_find:
             response = self.client.get(f"{self.endpoint}/1", headers=valid_header)
 
-        # mock_find.asseasdflkjalskdjfasd_once_with(1)
         mock_find.assert_called_once_with(1)
         assert response.status_code == 200
         assert response.json == LeaseSerializer.serialize(lease)

--- a/tests/integration/test_leases.py
+++ b/tests/integration/test_leases.py
@@ -15,6 +15,7 @@ class TestLease:
         with patch.object(LeaseModel, "find", return_value=lease) as mock_find:
             response = self.client.get(f"{self.endpoint}/1", headers=valid_header)
 
+        # mock_find.asseasdflkjalskdjfasd_once_with(1)
         mock_find.assert_called_once_with(1)
         assert response.status_code == 200
         assert response.json == LeaseSerializer.serialize(lease)

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -116,8 +116,9 @@ class TestOverwrittenAndInheritedMethods:
         UserModel.update(UserSchema, user.id, {"email": email})
         lookedup = UserModel.find(user.id)
         assert lookedup.email == email
-        assert lookedup.password is None
-        assert lookedup.hash_digest == user.hash_digest
+        # assert lookedup.password is None
+        # assert lookedup.hash_digest == user.hash_digest
+        assert lookedup.password == user.password
 
     def test_create_class_method(self, user_attributes):
         user = UserModel.create(UserSchema, user_attributes(role=RoleEnum.STAFF.value))

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -116,8 +116,6 @@ class TestOverwrittenAndInheritedMethods:
         UserModel.update(UserSchema, user.id, {"email": email})
         lookedup = UserModel.find(user.id)
         assert lookedup.email == email
-        # assert lookedup.password is None
-        # assert lookedup.hash_digest == user.hash_digest
         assert lookedup.password == user.password
 
     def test_create_class_method(self, user_attributes):

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -101,14 +101,6 @@ class TestFixtures:
 
 @pytest.mark.usefixtures("empty_test_db")
 class TestOverwrittenAndInheritedMethods:
-    def test_user_save_to_db(self, user_attributes):
-        attrs = UserModel.validate(
-            UserSchema, user_attributes(role=RoleEnum.STAFF.value)
-        )
-        user = UserModel(**attrs)
-        user.save_to_db()
-        lookedup = UserModel.find(user.id)
-        assert lookedup.password is None
 
     def test_update_class_method(self, create_join_staff, faker):
         user = create_join_staff()
@@ -116,9 +108,3 @@ class TestOverwrittenAndInheritedMethods:
         UserModel.update(UserSchema, user.id, {"email": email})
         lookedup = UserModel.find(user.id)
         assert lookedup.email == email
-        assert lookedup.password == user.password
-
-    def test_create_class_method(self, user_attributes):
-        user = UserModel.create(UserSchema, user_attributes(role=RoleEnum.STAFF.value))
-        lookedup = UserModel.find(user.id)
-        assert lookedup.password is None

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -101,7 +101,6 @@ class TestFixtures:
 
 @pytest.mark.usefixtures("empty_test_db")
 class TestOverwrittenAndInheritedMethods:
-
     def test_update_class_method(self, create_join_staff, faker):
         user = create_join_staff()
         email = faker.unique.email()


### PR DESCRIPTION
## Description
The "_hash_digest " field is now deleted and the "password " field is used

### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/###
