### PR TITLE
Use `valid_header` for emergency contacts integration tests

### DIFF
--- a/tests/integration/test_emergency_contacts.py
+++ b/tests/integration/test_emergency_contacts.py
@@ -34,7 +34,7 @@ def test_emergency_contacts_GET_one(client, test_database):
     assert response.json == {"message": "EmergencyContact not found"}
 
 
-def test_emergency_contacts_POST(client, valid_header, empty_test_db):
+def test_emergency_contacts_POST(test_database, client, valid_header):
     newContact = {
         "name": "Narcotics Anonymous",
         "description": "Cool description",
@@ -109,7 +109,7 @@ def test_emergency_contacts_PUT(client, valid_header, empty_test_db):
     assert response.json == {"message": "Emergency contact not found"}
 
 
-def test_emergency_contacts_DELETE(client, valid_header, empty_test_db):
+def test_emergency_contacts_DELETE(test_database, client, valid_header):
     id = 1
 
     response = client.delete(f"{endpoint}/{id}", headers=valid_header)


### PR DESCRIPTION
## Description

Replaces `auth_headers` with `valid_header` in emergency contacts tests, so that we can move away from testing authorization in these tests.

Additionally, uses `test_database` where necessary. The original issue had mentioned using `empty_test_db`, but I found that the tests depended on the populated test db.

This PR seems to introduce two warnings on the emergency contacts tests, but I can't figure out how to view the warnings with pytest -_-

### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/594
