### PR TITLE
Add gatekeeper utility to check request params

### DIFF
--- a/config/routes.py
+++ b/config/routes.py
@@ -1,4 +1,3 @@
-from tests.factory_fixtures.dummy_resource import DummyResource
 from flask_restful import Api
 from resources.user import (
     UserRegister,
@@ -52,6 +51,3 @@ class Routes:
         api.add_resource(
             ResetPassword, "reset-password", "reset-password/<string:token>"
         )
-
-        if app.env == "testing":
-            api.add_resource(DummyResource, "dummy")

--- a/config/routes.py
+++ b/config/routes.py
@@ -1,3 +1,4 @@
+from tests.factory_fixtures.dummy_resource import DummyResource
 from flask_restful import Api
 from resources.user import (
     UserRegister,
@@ -51,3 +52,6 @@ class Routes:
         api.add_resource(
             ResetPassword, "reset-password", "reset-password/<string:token>"
         )
+
+        if app.env == "testing":
+            api.add_resource(DummyResource, "dummy")

--- a/tests/factory_fixtures/dummy_resource.py
+++ b/tests/factory_fixtures/dummy_resource.py
@@ -1,0 +1,11 @@
+from flask import request
+from flask_restful import Resource
+from utils.gatekeeper import allowed_params
+
+
+class DummyResource(Resource):
+    dummy_params = set()
+
+    @allowed_params(dummy_params)
+    def put(self):
+        return request.json

--- a/tests/integration/test_gatekeeper.py
+++ b/tests/integration/test_gatekeeper.py
@@ -1,4 +1,5 @@
 import pytest
+from flask import current_app, request
 from tests.factory_fixtures.dummy_resource import DummyResource
 from utils.gatekeeper import GatekeeperError
 
@@ -7,17 +8,20 @@ from utils.gatekeeper import GatekeeperError
 class TestGatekeeper:
     def test_empty_set_allows_no_params(self):
         with pytest.raises(GatekeeperError):
-            self.client.put("/api/dummy", json={"hi": "there"})
+            with current_app.test_request_context(json={"hi": "there"}):
+                DummyResource.put(request)
 
     def test_raises_error_for_unspecified_params(self):
         DummyResource.dummy_params.update({"hello", "world"})
 
         with pytest.raises(GatekeeperError) as error_info:
-            self.client.put("/api/dummy", json={"hi": "there"})
+            with current_app.test_request_context(json={"hi": "there"}):
+                DummyResource.put(request)
         assert "Invalid request field" in str(error_info.value)
 
         DummyResource.dummy_params.clear()
 
     def test_subset_of_allowed_params_is_okay(self):
         DummyResource.dummy_params.update({"hello", "world", "again"})
-        self.client.put("/api/dummy", json={"hello": "there"})
+        with current_app.test_request_context(json={"hello": "there"}):
+            DummyResource.put(request)

--- a/tests/integration/test_gatekeeper.py
+++ b/tests/integration/test_gatekeeper.py
@@ -1,5 +1,5 @@
 import pytest
-from flask import current_app, request
+from flask import current_app
 from tests.factory_fixtures.dummy_resource import DummyResource
 from utils.gatekeeper import GatekeeperError
 
@@ -9,14 +9,14 @@ class TestGatekeeper:
     def test_empty_set_allows_no_params(self):
         with pytest.raises(GatekeeperError):
             with current_app.test_request_context(json={"hi": "there"}):
-                DummyResource.put(request)
+                DummyResource().put()
 
     def test_raises_error_for_unspecified_params(self):
         DummyResource.dummy_params.update({"hello", "world"})
 
         with pytest.raises(GatekeeperError) as error_info:
             with current_app.test_request_context(json={"hi": "there"}):
-                DummyResource.put(request)
+                DummyResource().put()
         assert "Invalid request field" in str(error_info.value)
 
         DummyResource.dummy_params.clear()
@@ -24,4 +24,4 @@ class TestGatekeeper:
     def test_subset_of_allowed_params_is_okay(self):
         DummyResource.dummy_params.update({"hello", "world", "again"})
         with current_app.test_request_context(json={"hello": "there"}):
-            DummyResource.put(request)
+            DummyResource().put()

--- a/tests/integration/test_gatekeeper.py
+++ b/tests/integration/test_gatekeeper.py
@@ -1,0 +1,23 @@
+import pytest
+from tests.factory_fixtures.dummy_resource import DummyResource
+from utils.gatekeeper import GatekeeperError
+
+
+@pytest.mark.usefixtures("client_class")
+class TestGatekeeper:
+    def test_empty_set_allows_no_params(self):
+        with pytest.raises(GatekeeperError):
+            self.client.put("/api/dummy", json={"hi": "there"})
+
+    def test_raises_error_for_unspecified_params(self):
+        DummyResource.dummy_params.update({"hello", "world"})
+
+        with pytest.raises(GatekeeperError) as error_info:
+            self.client.put("/api/dummy", json={"hi": "there"})
+        assert "Invalid request field" in str(error_info.value)
+
+        DummyResource.dummy_params.clear()
+
+    def test_subset_of_allowed_params_is_okay(self):
+        DummyResource.dummy_params.update({"hello", "world", "again"})
+        self.client.put("/api/dummy", json={"hello": "there"})

--- a/utils/gatekeeper.py
+++ b/utils/gatekeeper.py
@@ -1,0 +1,33 @@
+from flask import current_app, request
+from functools import wraps
+from typing import Set
+
+
+def allowed_params(params: Set[str]):
+    def decorator(endpoint):
+        @wraps(endpoint)
+        def verify_fields(*args, **kwargs):
+            if not (request.json.keys() <= params):
+                return invalid_field_error(params)
+            return endpoint(*args, **kwargs)
+
+        return verify_fields
+
+    return decorator
+
+
+def invalid_field_error(field_set):
+    if current_app.env == "development":
+        raise GatekeeperError(field_set)
+    else:
+        return {"message": "Invalid request field"}, 400
+
+
+class GatekeeperError(Exception):
+    def __init__(self, field_set, message="Invalid request field"):
+        self.field_set = field_set
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.message}: request fields must be one or more of {self.field_set}"

--- a/utils/gatekeeper.py
+++ b/utils/gatekeeper.py
@@ -17,10 +17,10 @@ def allowed_params(params: Set[str]):
 
 
 def invalid_field_error(field_set):
-    if current_app.env == "development":
-        raise GatekeeperError(field_set)
-    else:
+    if current_app.env == "production":
         return {"message": "Invalid request field"}, 400
+    else:
+        raise GatekeeperError(field_set)
 
 
 class GatekeeperError(Exception):


### PR DESCRIPTION
## Description

Use the `@allowed_params` decorator to restrict an endpoint to only
accept certain fields in the JSON request.

Decorator takes a set of strings as its only argument.

### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/642

