### PR TITLE
Remove remaining auth_headers

### DIFF
--- a/resources/user.py
+++ b/resources/user.py
@@ -114,9 +114,9 @@ class User(Resource):
                 "refresh_token": create_refresh_token(user.id),
             }
             user.update_last_active()
-            return {**user.json(), **new_tokens}, 201
+            return {**user.json(), **new_tokens}, 200
 
-        return user.json(), 201
+        return user.json(), 200
 
     @admin_required
     def delete(self, user_id):

--- a/tests/authorizations/test_email_authorization.py
+++ b/tests/authorizations/test_email_authorization.py
@@ -19,7 +19,7 @@ class TestEmailAuthorizations:
             "subject": "PM's email subject",
             "body": "I'm a property manager",
         }
-        response = self.client.post(self.endpoint, json=payload, headers=pm_header)
+        response = self.client.post(self.endpoint, json=payload, headers=pm_header())
         assert is_valid(response, 401)
 
     def test_admin_is_allowed_access(self, admin_header, create_join_staff):
@@ -37,5 +37,5 @@ class TestEmailAuthorizations:
             "subject": "Staff's email subject",
             "body": "I'm staff",
         }
-        response = self.client.post(self.endpoint, json=payload, headers=staff_header)
+        response = self.client.post(self.endpoint, json=payload, headers=staff_header())
         assert is_valid(response, 401)

--- a/tests/authorizations/test_emergency_contact_authorization.py
+++ b/tests/authorizations/test_emergency_contact_authorization.py
@@ -30,25 +30,25 @@ class TestEmergenyContactsAuthorizations:
 
     def test_prop_manager_denied_emerg_contacts_POST(self, pm_header):
         response = self.client.post(
-            self.endpoint, json=self.newContact, headers=pm_header
+            self.endpoint, json=self.newContact, headers=pm_header()
         )
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
     def test_prop_manager_denied_emerg_contacts_DELETE(self, pm_header):
         response = self.client.delete(
-            f"{self.endpoint}/{self.user_id}", headers=pm_header
+            f"{self.endpoint}/{self.user_id}", headers=pm_header()
         )
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
     def test_staff_denied_emerg_contacts_POST(self, staff_header):
         response = self.client.post(
-            self.endpoint, json=self.newContact, headers=staff_header
+            self.endpoint, json=self.newContact, headers=staff_header()
         )
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
     def test_staff_denied_emerg_contacts_DELETE(self, staff_header):
         response = self.client.delete(
-            f"{self.endpoint}/{self.user_id}", headers=staff_header
+            f"{self.endpoint}/{self.user_id}", headers=staff_header()
         )
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 

--- a/tests/authorizations/test_lease_authorization.py
+++ b/tests/authorizations/test_lease_authorization.py
@@ -37,13 +37,13 @@ class TestLeaseAuthorizations:
     def test_pm_authorized_to_get(self, pm_header, create_lease):
         lease = create_lease()
 
-        response = self.client.get(f"/api/lease/{lease.id}", headers=pm_header)
+        response = self.client.get(f"/api/lease/{lease.id}", headers=pm_header())
         assert response.status_code == 200
 
     def test_staff_are_authorized_to_get(self, staff_header, create_lease):
         lease = create_lease()
 
-        response = self.client.get(f"/api/lease/{lease.id}", headers=staff_header)
+        response = self.client.get(f"/api/lease/{lease.id}", headers=staff_header())
         assert response.status_code == 200
 
     def test_admin_is_authorized_to_get(self, admin_header, create_lease):
@@ -54,12 +54,12 @@ class TestLeaseAuthorizations:
 
     def test_pm_is_authorized_to_get_all(self, pm_header, create_lease):
 
-        response = self.client.get("/api/lease", headers=pm_header)
+        response = self.client.get("/api/lease", headers=pm_header())
         assert response.status_code == 200
 
     def test_staff_are_authorized_to_get_all(self, staff_header, create_lease):
 
-        response = self.client.get("/api/lease", headers=staff_header)
+        response = self.client.get("/api/lease", headers=staff_header())
         assert response.status_code == 200
 
     def test_admin_is_authorized_to_get_all(self, admin_header, create_lease):
@@ -67,13 +67,11 @@ class TestLeaseAuthorizations:
         response = self.client.get("/api/lease", headers=admin_header)
         assert response.status_code == 200
 
-    def test_pm_is_authorized_to_create(
-        self, pm_header, create_tenant, lease_payload
-    ):
+    def test_pm_is_authorized_to_create(self, pm_header, create_tenant, lease_payload):
         response = self.client.post(
             "/api/lease",
             json=self.valid_payload(create_tenant(), lease_payload()),
-            headers=pm_header,
+            headers=pm_header(),
         )
 
         assert response.status_code == 201
@@ -84,7 +82,7 @@ class TestLeaseAuthorizations:
         response = self.client.post(
             "/api/lease",
             json=self.valid_payload(create_tenant(), lease_payload()),
-            headers=staff_header,
+            headers=staff_header(),
         )
         assert response.status_code == 201
 
@@ -101,7 +99,7 @@ class TestLeaseAuthorizations:
     def test_pm_is_authorized_to_delete_lease(self, pm_header, create_lease):
         lease = create_lease()
         response = self.client.delete(
-            f"/api/lease/{lease.id}".format(id), headers=pm_header
+            f"/api/lease/{lease.id}".format(id), headers=pm_header()
         )
 
         assert response.status_code == 200
@@ -109,7 +107,7 @@ class TestLeaseAuthorizations:
     def test_staff_are_authorized_to_delete_lease(self, staff_header, create_lease):
         lease = create_lease()
         response = self.client.delete(
-            f"/api/lease/{lease.id}".format(id), headers=staff_header
+            f"/api/lease/{lease.id}".format(id), headers=staff_header()
         )
 
         assert response.status_code == 200
@@ -129,7 +127,7 @@ class TestLeaseAuthorizations:
             "dateTimeEnd": Time.one_year_from_now_iso(),
         }
         response = self.client.put(
-            f"/api/lease/{lease.id}", json=payload, headers=pm_header
+            f"/api/lease/{lease.id}", json=payload, headers=pm_header()
         )
         assert response.status_code == 200
 
@@ -140,7 +138,7 @@ class TestLeaseAuthorizations:
             "dateTimeEnd": Time.one_year_from_now_iso(),
         }
         response = self.client.put(
-            f"/api/lease/{lease.id}", json=payload, headers=staff_header
+            f"/api/lease/{lease.id}", json=payload, headers=staff_header()
         )
         assert response.status_code == 200
 

--- a/tests/authorizations/test_lease_authorization.py
+++ b/tests/authorizations/test_lease_authorization.py
@@ -4,13 +4,8 @@ import pytest
 
 @pytest.mark.usefixtures("client_class", "empty_test_db")
 class TestLeaseAuthorizations:
-    def valid_payload(self, tenant_id, property_id):
-        return {
-            "dateTimeStart": Time.today_iso(),
-            "dateTimeEnd": Time.one_year_from_now_iso(),
-            "tenantID": tenant_id,
-            "propertyID": property_id,
-        }
+    def valid_payload(self, tenant, lease):
+        return {"tenantID": tenant.id, **lease}
 
     # Test auth is in place at each endpoint
     def test_unauthorized_get_request(self):
@@ -73,38 +68,32 @@ class TestLeaseAuthorizations:
         assert response.status_code == 200
 
     def test_pm_is_authorized_to_create(
-        self, pm_header, create_tenant, create_property
+        self, pm_header, create_tenant, lease_payload
     ):
-        tenant = create_tenant()
-        propertyID = create_property().id
         response = self.client.post(
             "/api/lease",
-            json=self.valid_payload(tenant.id, propertyID),
+            json=self.valid_payload(create_tenant(), lease_payload()),
             headers=pm_header,
         )
 
         assert response.status_code == 201
 
     def test_staff_are_authorized_to_create(
-        self, staff_header, create_tenant, create_property
+        self, staff_header, create_tenant, lease_payload
     ):
-        tenant = create_tenant()
-        propertyID = create_property().id
         response = self.client.post(
             "/api/lease",
-            json=self.valid_payload(tenant.id, propertyID),
+            json=self.valid_payload(create_tenant(), lease_payload()),
             headers=staff_header,
         )
         assert response.status_code == 201
 
     def test_admin_is_authorized_to_create(
-        self, admin_header, create_tenant, create_property
+        self, admin_header, create_tenant, lease_payload
     ):
-        tenant = create_tenant()
-        propertyID = create_property().id
         response = self.client.post(
             "/api/lease",
-            json=self.valid_payload(tenant.id, propertyID),
+            json=self.valid_payload(create_tenant(), lease_payload()),
             headers=admin_header,
         )
         assert response.status_code == 201

--- a/tests/authorizations/test_property_authorization.py
+++ b/tests/authorizations/test_property_authorization.py
@@ -33,6 +33,6 @@ class TestPropertyAuthorizations:
     def test_archive_properties_non_admin(self, staff_header):
         """The server responds with a 401 error if a non-admin tries to archive"""
         responseNoAdmin = self.client.patch(
-            "/api/properties/archive", json={}, headers=staff_header
+            "/api/properties/archive", json={}, headers=staff_header()
         )
         assert responseNoAdmin == 401

--- a/tests/authorizations/test_staff_tenant_authorization.py
+++ b/tests/authorizations/test_staff_tenant_authorization.py
@@ -26,7 +26,7 @@ class TestStaffTenantAuthorizations:
             json=TestStaffTenantAuthorizations.valid_payload(
                 tenants=[create_tenant().id], staff=[create_join_staff().id]
             ),
-            headers=pm_header,
+            headers=pm_header(),
         )
 
         assert response.status_code == 401
@@ -39,7 +39,7 @@ class TestStaffTenantAuthorizations:
             json=TestStaffTenantAuthorizations.valid_payload(
                 tenants=[create_tenant().id], staff=[create_join_staff().id]
             ),
-            headers=staff_header,
+            headers=staff_header(),
         )
 
         assert response.status_code == 401

--- a/tests/authorizations/test_tenant_authorization.py
+++ b/tests/authorizations/test_tenant_authorization.py
@@ -7,7 +7,7 @@ class TestTenantAuthorization:
     def setup(self):
         self.endpoint = "/api/tenants"
 
-    def test_post(self, create_join_staff, auth_headers):
+    def test_post(self, create_join_staff, pm_header):
         staff_1 = create_join_staff()
         staff_2 = create_join_staff()
         newTenant = {
@@ -16,9 +16,7 @@ class TestTenantAuthorization:
             "phone": "111-111-1111",
             "staffIDs": [staff_1.id, staff_2.id],
         }
-        response = self.client.post(
-            self.endpoint, json=newTenant, headers=auth_headers["pm"]
-        )
+        response = self.client.post(self.endpoint, json=newTenant, headers=pm_header())
         assert is_valid(response, 401)  # UNAUTHORIZED - Admin Access Required
 
         response = self.client.post(self.endpoint, json=newTenant)

--- a/tests/factory_fixtures/user.py
+++ b/tests/factory_fixtures/user.py
@@ -1,4 +1,5 @@
 import pytest
+import random
 from models.user import UserModel, RoleEnum
 from models.users.admin import Admin
 from models.users.staff import Staff
@@ -7,10 +8,12 @@ from models.users.property_manager import PropertyManager
 
 @pytest.fixture
 def user_attributes(faker):
-    def _user_attributes(role=None, archived=False, firstName=None, lastName=None):
+    def _user_attributes(
+        role=None, archived=False, firstName=None, lastName=None, pw=None
+    ):
         return {
             "email": faker.unique.email(),
-            "password": faker.password(),
+            "password": pw if pw else faker.password(),
             "firstName": firstName if firstName else faker.first_name(),
             "lastName": lastName if lastName else faker.last_name(),
             "phone": faker.phone_number(),
@@ -23,12 +26,13 @@ def user_attributes(faker):
 
 @pytest.fixture
 def create_admin_user(user_attributes):
-    def _create_admin_user(firstName=None, lastName=None):
+    def _create_admin_user(firstName=None, lastName=None, pw=None):
         admin = Admin(
             **user_attributes(
                 role=RoleEnum.ADMIN,
                 firstName=firstName,
                 lastName=lastName,
+                pw=pw,
             )
         )
         admin.save_to_db()
@@ -39,8 +43,8 @@ def create_admin_user(user_attributes):
 
 @pytest.fixture
 def create_join_staff(user_attributes):
-    def _create_join_staff():
-        staff = Staff(**user_attributes(role=RoleEnum.STAFF))
+    def _create_join_staff(pw=None):
+        staff = Staff(**user_attributes(role=RoleEnum.STAFF, pw=pw))
         staff.save_to_db()
         return staff
 
@@ -49,8 +53,8 @@ def create_join_staff(user_attributes):
 
 @pytest.fixture
 def create_property_manager(user_attributes):
-    def _create_property_manager():
-        pm = PropertyManager(**user_attributes(role=RoleEnum.PROPERTY_MANAGER))
+    def _create_property_manager(pw=None):
+        pm = PropertyManager(**user_attributes(role=RoleEnum.PROPERTY_MANAGER, pw=pw))
         pm.save_to_db()
         return pm
 
@@ -59,9 +63,30 @@ def create_property_manager(user_attributes):
 
 @pytest.fixture
 def create_unauthorized_user(user_attributes):
-    def _create_unauthorized_user():
-        user = UserModel(**user_attributes())
+    def _create_unauthorized_user(pw=None):
+        user = UserModel(**user_attributes(pw=pw))
         user.save_to_db()
         return user
 
     yield _create_unauthorized_user
+
+
+@pytest.fixture
+def create_user(
+    user_attributes, create_admin_user, create_join_staff, create_property_manager
+):
+    def _create_user(pw=None, admin=True):
+        if admin:
+            return random.choice(
+                [
+                    create_admin_user(pw=pw),
+                    create_join_staff(pw=pw),
+                    create_property_manager(pw=pw),
+                ]
+            )
+        else:
+            return random.choice(
+                [create_join_staff(pw=pw), create_property_manager(pw=pw)]
+            )
+
+    yield _create_user

--- a/tests/integration/test_mailers.py
+++ b/tests/integration/test_mailers.py
@@ -57,14 +57,14 @@ class TestPostEmail:
 @pytest.mark.usefixtures("empty_test_db")
 class TesttEmail:
     @patch.object(EmailMessage, "send")
-    def test_reset_password_msg(self, send_mail_msg, new_user):
+    def test_reset_password_msg(self, send_mail_msg, create_user):
         with patch.object(EmailMessage, "__init__", return_value=None):
-            Email.send_reset_password_msg(new_user)
+            Email.send_reset_password_msg(create_user())
 
         send_mail_msg.assert_called()
 
     @patch.object(EmailMessage, "send")
-    def test_send_user_invite_msg(self, send_mail_msg, new_user):
+    def test_send_user_invite_msg(self, send_mail_msg, create_user):
         with patch.object(EmailMessage, "__init__", return_value=None):
-            Email.send_user_invite_msg(new_user)
+            Email.send_user_invite_msg(create_user())
         send_mail_msg.assert_called()

--- a/tests/integration/test_reset_password.py
+++ b/tests/integration/test_reset_password.py
@@ -52,19 +52,18 @@ class TestResetPasswordGET:
         assert response.status == "422 UNPROCESSABLE ENTITY"
         assert response.json == {"message": "Not enough segments"}
 
-    def test_request_with_expired_token(self, new_user):
+    def test_request_with_expired_token(self, create_user):
         with freeze_time(Time.yesterday()):
-            token = new_user.reset_password_token()
+            token = create_user().reset_password_token()
 
         response = self.client.get(f"{self.endpoint}/{token}")
 
         assert response.status == "422 UNPROCESSABLE ENTITY"
         assert response.json == {"message": "Expired token"}
 
-    def test_request_with_valid_token(self, new_user):
-        token = new_user.reset_password_token()
-
-        response = self.client.get(f"{self.endpoint}/{token}")
+    def test_request_with_valid_token(self, create_user):
+        user = create_user()
+        response = self.client.get(f"{self.endpoint}/{user.reset_password_token()}")
 
         assert response.status == "200 OK"
-        assert response.json == {"message": "Valid token", "user_id": new_user.id}
+        assert response.json == {"message": "Valid token", "user_id": user.id}


### PR DESCRIPTION
## Description

- Removed remaining auth headers.
- Created new `create_user` factory
- Created new `header` factory
    - This factory can be used if a specific user needs to be used to generate the header
 
- Dried up header factories.
- Changed user patch response status code from 201 to 200
- Updated user factories to take an optional password argument

Fixes codeforpdx/dwellingly-app/issues/633
Fixes codeforpdx/dwellingly-app/issues/635
