### PR TITLE
Monkeypatch env setting for tests

### DIFF
--- a/config/environment.py
+++ b/config/environment.py
@@ -39,7 +39,6 @@ class Development(Default):
 
 
 class Testing(Default):
-    os.environ["FLASK_ENV"] = "testing"
     TESTING = True
     SQLALCHEMY_DATABASE_URI = os.environ.get("TEST_DATABASE_URL") or "sqlite://"
     WORK_FACTOR = 4

--- a/conftest.py
+++ b/conftest.py
@@ -7,8 +7,14 @@ from db import db
 from tests.factory_fixtures import *  # noqa: F401, F403
 
 
+@pytest.fixture(autouse=True)
+def environment(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+
+
 @pytest.fixture
-def app():
+def app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
     app = create_app("testing")
     return app
 


### PR DESCRIPTION
The previous setup bled through all the environments.

Monkeypatch the environment in the conftest file so that it doesn't
bleed through all environments.

An autouse fixture defines the Flask environment for tests that do
not use the app context. For tests that do need an app context
then it also needs to be defined before the app loads which is
done in the app method.

https://docs.pytest.org/en/6.2.x/reference.html#monkeypatch