### PR TITLE
Add updated_at and created_at to property model json

### DIFF
--- a/models/property.py
+++ b/models/property.py
@@ -3,6 +3,7 @@ from nobiru.nobiru_list import NobiruList
 from models.base_model import BaseModel
 from models.user import UserModel
 from models.property_assignment import PropertyAssignment
+from utils.time import Time
 
 
 class PropertyModel(BaseModel):
@@ -43,6 +44,8 @@ class PropertyModel(BaseModel):
             "zipcode": self.zipcode,
             "leases": self.leases.json(),
             "archived": self.archived,
+            "created_at": Time.format_date(self.created_at),
+            "updated_at": Time.format_date(self.updated_at),
         }
         if include_tenants:
             property["tenants"] = self.tenants()

--- a/tests/unit/test_property.py
+++ b/tests/unit/test_property.py
@@ -40,6 +40,8 @@ class TestPropertyModel:
             "leases": [lease_1.json(), lease_2.json()],
             "propertyManagers": [manager_1.json(), manager_2.json()],
             "archived": property.archived,
+            "created_at": Time.format_date(property.created_at),
+            "updated_at": Time.format_date(property.updated_at),
         }
 
     def test_json_with_tenants(self, create_property, create_lease):


### PR DESCRIPTION
## Description
Return property updated_at and created_at in property model json serialization so the frontend can consume it

### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/671
