### PR TITLE
Update env vars

### DIFF
--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -15,6 +15,7 @@ env:
   SECRET_KEY: dwellingly
   TEST_DATABASE_URL: postgresql://localhost/dwellingly_test
   FLASK_ENV: testing
+  REACT_APP_PROXY: http://localhost:5000
 
 jobs:
   system_test:


### PR DESCRIPTION
Updating due to frontend changes in env vars. The React env var is no long commited to git.
