### PR TITLE
Do not import seed file at top level of manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,6 @@
 import click
+
 from db import db
-from data.seed import Seed
 from flask import Blueprint
 
 dbsetup = Blueprint("db", __name__)
@@ -12,7 +12,8 @@ dbsetup = Blueprint("db", __name__)
 
 @dbsetup.cli.command("seed")
 def seed():
-    """Seed the database with default data"""
+    from data.seed import Seed
+
     Seed().data()
 
 
@@ -35,6 +36,8 @@ def recreate():
     Recreates database table and populates with seed data.
     Know that this will reset your db to defaults
     """
+    from data.seed import Seed
+
     if click.confirm("Are you sure you want to lose all your data"):
         db.drop_all()
         db.create_all()

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,6 @@
+from models.user import UserModel
+from models.users.admin import Admin
+from models.users.staff import Staff
+from models.users.property_manager import PropertyManager
+
+from models.property import PropertyModel


### PR DESCRIPTION
## Description

The remote dev server is down due to faker being used in the seed file. The seed file isn't production related so anything in that file should not be parsed unless strictly told to do so.

Importing the seed file at the top level causes all environments to
parse the seed file. Which causes issues for the production environment,
because the seed file contains non-production libraries that are
imported in the seed file, but not available in the production environment.
Plus we don't want to import/run any code that is not necessary in Production.
