### PR TITLE
Add clarification for postgresql version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ Queries can be made with the Postman Collection link ( https://www.getpostman.co
 
 ### PostgreSQL Setup
 
-1. Install [PostgreSQL](https://www.postgresql.org/download/).
+1. Install [PostgreSQL](https://www.postgresql.org/download/) version 14.
 2. Manually create the database.
    - From a linux or mac command line run the following:
      ```shell


### PR DESCRIPTION
## Description
The PostgreSQL download page shows multiple versions, but the guide didn't specify which version should be used. I added "version 14" next to the link to reduce ambiguity.