### PR TITLE
Allow api to accept the actual values of a Ticket status

### DIFF
--- a/models/tickets.py
+++ b/models/tickets.py
@@ -3,23 +3,18 @@ from nobiru.nobiru_list import NobiruList
 from datetime import datetime, timedelta
 from models.base_model import BaseModel
 from utils.time import Time
-import enum
-
-
-class TicketStatus(str, enum.Enum):
-    New = "New"
-    In_Progress = "In Progress"
-    Closed = "Closed"
 
 
 class TicketModel(BaseModel):
+    STATUSES = ("New", "In Progress", "Closed")
+
     __tablename__ = "tickets"
 
     id = db.Column(db.Integer, primary_key=True)
     issue = db.Column(db.String(144))
     tenant_id = db.Column(db.Integer, db.ForeignKey("tenants.id"), nullable=False)
     author_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
-    status = db.Column(db.Enum(TicketStatus), default=TicketStatus.New, nullable=False)
+    status = db.Column(db.String, default=STATUSES[0], nullable=False)
     urgency = db.Column(db.String(12))
 
     notes = db.relationship(

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -22,3 +22,8 @@ class TicketSchema(ma.SQLAlchemyAutoSchema):
     def validate_author(self, value):
         if not UserModel.query.get(value):
             raise ValidationError(f"{value} is not a valid user ID")
+
+    @validates("status")
+    def validate_status(self, value):
+        if value not in TicketModel.STATUSES:
+            raise ValidationError(f"{value} is not a valid status")

--- a/shelltools.py
+++ b/shelltools.py
@@ -12,5 +12,5 @@ from models.lease import LeaseModel
 from models.property import PropertyModel
 from models.tenant import TenantModel
 
-from models.tickets import TicketModel, TicketStatus
+from models.tickets import TicketModel
 from models.notes import NotesModel

--- a/tests/attributes.py
+++ b/tests/attributes.py
@@ -4,7 +4,7 @@
 # without needing to import additional libraries that are not needed.
 # This mostly concerns libraries that would not be used in Production.
 from utils.time import Time
-from models.tickets import TicketStatus
+from models.tickets import TicketModel
 
 
 def contact_number_attrs(faker):
@@ -57,9 +57,7 @@ def ticket_attrs(faker, issue=None):
     return {
         "issue": issue or faker.sentence(),
         "urgency": faker.random_element(("Low", "Medium", "High")),
-        "status": faker.random_element(
-            [member.name for name, member in TicketStatus.__members__.items()]
-        ),
+        "status": faker.random_element(TicketModel.STATUSES),
     }
 
 

--- a/tests/schemas/test_ticket_schema.py
+++ b/tests/schemas/test_ticket_schema.py
@@ -5,7 +5,6 @@ from schemas import TicketSchema
 @pytest.mark.usefixtures("empty_test_db")
 class TestTicketValidations:
     def test_valid_payload(self, create_tenant, create_admin_user):
-
         valid_payload = {
             "tenant_id": create_tenant().id,
             "author_id": create_admin_user().id,
@@ -13,3 +12,14 @@ class TestTicketValidations:
 
         no_validation_errors = {}
         assert no_validation_errors == TicketSchema().validate(valid_payload)
+
+    def test_status_validation(self, ticket_attributes):
+        no_validation_errors = {}
+        payload = ticket_attributes()
+        for status in ("New", "In Progress", "Closed"):
+            payload["status"] = status
+            assert no_validation_errors == TicketSchema().validate(payload)
+
+        payload["status"] = "123456789"
+        validation_errors = TicketSchema().validate(payload)
+        assert "status" in validation_errors

--- a/tests/unit/test_ticket.py
+++ b/tests/unit/test_ticket.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.unit.base_interface_test import BaseInterfaceTest
 from models.tickets import TicketModel
 from schemas.ticket import TicketSchema
@@ -24,3 +26,10 @@ class TestBaseTicketModel(BaseInterfaceTest):
 
         validation_errors = TicketSchema().validate(invalid_author)
         assert invalid_author_validation_error == validation_errors["author_id"]
+
+
+@pytest.mark.usefixtures("empty_test_db")
+class TestFixtures:
+    def test_create_ticket(self, create_ticket):
+        ticket = create_ticket()
+        assert ticket


### PR DESCRIPTION
The previous implementation created a hard dependency when working with
a Ticket. The requestor needed to know the keys used in the backed and
how those keys mapped to the actual ticket status.

Because of this when someone made a request and wanted to move the
ticket to `In Progress` they would need to know that they had to send
the string `In_Progress`.

I decided to remove the enum that was in use, and changed the column to
a String. The TicketStatus was not being used in logic anywhere, and so
it seemed its only purpose was to validate the strings that went into
the db. To make things a bit more simpler it is removed for now, and a
straight tuple is created that is used to validate what goes into the
db.
