### PR TITLE
704/remove backend dependency

### DIFF
--- a/doc/using_the_api.md
+++ b/doc/using_the_api.md
@@ -292,12 +292,7 @@ All endpoints are prefixed with `/api/`
             },
         },
     },
-    'managers':{
-        'title': 'New Property Managers',
-        'link': '#',
-        'isDate': True,
-        'stats': [projectManagers]
-    }
-        }
+    'managers': projectManagers
+}
 
 ```

--- a/doc/using_the_api.md
+++ b/doc/using_the_api.md
@@ -267,35 +267,37 @@ All endpoints are prefixed with `/api/`
 | GET    | `/widgets/`        | Pull down Widget Info                               |
 
 ```javascript
-{ 'opentickets':{
-            'title': 'Open Tickets',
-            'stats': [[
-                {
-                    "stat": TicketModel.find_count_by_status("New"),
-                    "desc": 'New',
-                },
-                {
-                    "stat": TicketModel.find_count_by_update_status("New", 1440),
-                    "desc": "Unseen for > 24 hours",
-                }
-            ],
-            [
-                {
-                    "stat": TicketModel.find_count_by_status("In Progress"),
-                    "desc": 'In Progress'
-                },
-                {
-                    "stat": TicketModel.find_count_by_update_status("In Progress", 10080),
-                    "desc": 'In progress for > 1 week',
-                }
-            ]]
+{
+    'opentickets': {
+        "new": {
+            "allNew": {
+                "stat": TicketModel.find_count_by_status("New"),
+                "desc": "New",
+            },
+            "unseen24Hrs": {
+                "stat": TicketModel.find_count_by_update_status("New", 1440),
+                "desc": "Unseen for > 24 hours",
+            },
         },
-        'managers':{
-                'title': 'New Property Managers',
-                'link': '#',
-                'isDate': True,
-                'stats': [projectManagers]
-            }
+        "inProgress": {
+            "allInProgress": {
+                "stat": TicketModel.find_count_by_status("In Progress"),
+                "desc": "In Progress",
+            },
+            "inProgress1Week": {
+                "stat": TicketModel.find_count_by_update_status(
+                    "In Progress", 10080
+                ),
+                "desc": "In progress for > 1 week",
+            },
+        },
+    },
+    'managers':{
+        'title': 'New Property Managers',
+        'link': '#',
+        'isDate': True,
+        'stats': [projectManagers]
+    }
         }
 
 ```

--- a/models/user.py
+++ b/models/user.py
@@ -114,14 +114,6 @@ class UserModel(BaseModel):
     def serialize(self):
         return {}
 
-    def widgetJson(self, propertyName, date):
-        return {
-            "id": self.id,
-            "stat": date,
-            "desc": "{} {}".format(self.firstName, self.lastName),
-            "subtext": propertyName,
-        }
-
     @classmethod
     def find_by_email(cls, email):
         return cls.query.filter_by(email=email).first()

--- a/resources/widgets.py
+++ b/resources/widgets.py
@@ -75,5 +75,5 @@ class Widgets(Resource):
                     },
                 },
             },
-            "managers": [projectManagers],
+            "managers": projectManagers,
         }, 200

--- a/resources/widgets.py
+++ b/resources/widgets.py
@@ -37,56 +37,43 @@ class Widgets(Resource):
         users = UserModel.find_recent_role("property-manager", 5)
         projectManagers = []
 
-        nullPropertyManager = {
-            "id": " ",
-            "stat": " ",
-            "desc": "No new users",
-            "subtext": " ",
-        }
-
         for user in users:
             date = self.dateStringConversion(user.created_at)
             propertyName = self.returnPropertyName(user.id)
-            projectManagers.append(user.widgetJson(propertyName, date))
-
-        if len(projectManagers) == 0:
-            projectManagers.append(nullPropertyManager)
+            projectManagers.append(
+                {
+                    "id": user.id,
+                    "firstName": user.firstName,
+                    "lastName": user.lastName,
+                    "date": date,
+                    "propertyName": propertyName,
+                }
+            )
 
         return {
             "opentickets": {
-                "title": "Open Tickets",
-                "link": "/manage/tickets",
-                "stats": [
-                    [
-                        {
-                            "stat": TicketModel.find_count_by_status("New"),
-                            "desc": "New",
-                        },
-                        {
-                            "stat": TicketModel.find_count_by_update_status(
-                                "New", 1440
-                            ),
-                            "desc": "Unseen for > 24 hours",
-                        },
-                    ],
-                    [
-                        {
-                            "stat": TicketModel.find_count_by_status("In Progress"),
-                            "desc": "In Progress",
-                        },
-                        {
-                            "stat": TicketModel.find_count_by_update_status(
-                                "In Progress", 10080
-                            ),
-                            "desc": "In progress for > 1 week",
-                        },
-                    ],
-                ],
+                "new": {
+                    "allNew": {
+                        "stat": TicketModel.find_count_by_status("New"),
+                        "desc": "New",
+                    },
+                    "unseen24Hrs": {
+                        "stat": TicketModel.find_count_by_update_status("New", 1440),
+                        "desc": "Unseen for > 24 hours",
+                    },
+                },
+                "inProgress": {
+                    "allInProgress": {
+                        "stat": TicketModel.find_count_by_status("In Progress"),
+                        "desc": "In Progress",
+                    },
+                    "inProgress1Week": {
+                        "stat": TicketModel.find_count_by_update_status(
+                            "In Progress", 10080
+                        ),
+                        "desc": "In progress for > 1 week",
+                    },
+                },
             },
-            "managers": {
-                "title": "New Property Managers",
-                "link": "/manage/managers/",
-                "isDate": True,
-                "stats": [projectManagers],
-            },
+            "managers": [projectManagers],
         }, 200

--- a/tests/integration/test_widgets.py
+++ b/tests/integration/test_widgets.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+@pytest.mark.usefixtures("client_class", "empty_test_db")
+class TestWidgets:
+    def setup(self):
+        self.password = "strongestpasswordever"
+
+    def test_get_widgets(self, create_admin_user):
+        user = create_admin_user(pw=self.password)
+        response = self.client.post(
+            "/api/login",
+            json={"email": user.email, "password": self.password},
+        )
+        header = {"Authorization": f"Bearer {response.json['access_token']}"}
+        widgetResponse = self.client.get("/api/widgets", headers=header)
+
+        assert widgetResponse.status_code == 200
+        widgetJson = widgetResponse.json
+        assert len(widgetJson["opentickets"]) == 2
+        assert len(widgetJson["managers"]) == 0
+
+        # check for correct keys for new tickets
+        assert "new" in widgetJson["opentickets"]
+        assert "allNew" in widgetJson["opentickets"]["new"]
+        assert "unseen24Hrs" in widgetJson["opentickets"]["new"]
+
+        # check for correct keys for in-progress tickets
+        assert "inProgress" in widgetJson["opentickets"]
+        assert "allInProgress" in widgetJson["opentickets"]["inProgress"]
+        assert "inProgress1Week" in widgetJson["opentickets"]["inProgress"]

--- a/tests/integration/test_widgets.py
+++ b/tests/integration/test_widgets.py
@@ -6,17 +6,11 @@ class TestWidgets:
     def setup(self):
         self.password = "strongestpasswordever"
 
-    def test_get_widgets(self, create_admin_user):
-        user = create_admin_user(pw=self.password)
-        response = self.client.post(
-            "/api/login",
-            json={"email": user.email, "password": self.password},
-        )
-        header = {"Authorization": f"Bearer {response.json['access_token']}"}
-        widgetResponse = self.client.get("/api/widgets", headers=header)
+    def test_get_widgets(self, valid_header):
+        widget_response = self.client.get("/api/widgets", headers=valid_header)
 
-        assert widgetResponse.status_code == 200
-        widgetJson = widgetResponse.json
+        assert widget_response.status_code == 200
+        widgetJson = widget_response.json
         assert len(widgetJson["opentickets"]) == 2
         assert len(widgetJson["managers"]) == 0
 


### PR DESCRIPTION
### What issue is this solving?
Please connect this Pull Request to the issue it is resolving by using the controls on the right side of this PR.
closes codeforpdx/dwellingly-app#704 

### Any helpful knowledge/context for the reviewer?
This doesn't provided any change in behavior, it was rather just a re-assigning of who was responsible for what data. Now the frontend handles widget information such as the title, link, and labels. Whereas the backend is just concerned with providing the raw data.


There is a complementary PR in the frontend repo that'll need to be closed at the same time:  codeforpdx/dwellingly-app#710