### PR TITLE
Enable user to turn off/on logging from sqlalchemy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 SECRET_KEY='dwellingly'
 PYTHONPATH=${PWD}:${PYTHONPATH}
 
-# To set the database to postgresql. Uncomment the env vars below
+## Uncomment to see logging from sqlalchemy
+# DB_LOGGING=ON
+
+## To set the database to postgresql. Uncomment the env vars below
 # DEV_DATABASE_URL=postgresql://localhost/dwellingly_development
 # TEST_DATABASE_URL=postgresql://localhost/dwellingly_test

--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ def create_app(env):
     def format_unauthorized_message(message):
         return {app.config["JWT_ERROR_MESSAGE_KEY"]: message.capitalize()}, 401
 
-    if os.getenv("DB_LOGGING"):
+    if os.getenv("DB_LOGGING") == "ON":
         logging.basicConfig()
         logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
 

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from flask import Flask
 from flask_jwt_extended import JWTManager
@@ -55,8 +56,10 @@ def create_app(env):
     def format_unauthorized_message(message):
         return {app.config["JWT_ERROR_MESSAGE_KEY"]: message.capitalize()}, 401
 
-    logging.basicConfig()
-    logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
+    if os.getenv("DB_LOGGING"):
+        logging.basicConfig()
+        logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
+
     db.init_app(app)
     ma.init_app(app)
     return app


### PR DESCRIPTION
Sometimes the logging is useful, but other times it just gets in the
way. Enable the user to turn off/on logging as they desire from their
`.env` file.

For example when tests fail you'll often see large output from this logger, which can be helpful sometimes, but most of the time you just want to see the failure message.