### PR TITLE
Fix UserInvite to create the correct type of user

### DIFF
--- a/resources/user_invite.py
+++ b/resources/user_invite.py
@@ -1,9 +1,12 @@
 from flask_restful import Resource
 from flask import request
 from utils.authorizations import admin_required
-from models.user import UserModel
+from models.users.property_manager import PropertyManager
+from models.users.staff import Staff
+from models.users.admin import Admin
 from schemas import UserSchema
 from resources.email import Email
+from models.user import RoleEnum
 import string
 import random
 
@@ -11,10 +14,19 @@ import random
 class UserInvite(Resource):
     @admin_required
     def post(self):
-        data = request.json
         temp_password = "".join(random.choice(string.ascii_lowercase) for i in range(8))
-        user = UserModel.create(
-            schema=UserSchema, payload={**data, "password": temp_password}
+
+        user_class = self.user_type(request.json.get("type", request.json.get("role")))
+        user = user_class.create(
+            schema=UserSchema, payload={**request.json, "password": temp_password}
         )
         Email.send_user_invite_msg(user)
         return {"message": "User Invited"}, 201
+
+    def user_type(self, value):
+        if value == RoleEnum.PROPERTY_MANAGER.value or value == "property_manager":
+            return PropertyManager
+        elif value == RoleEnum.STAFF.value or value == "staff":
+            return Staff
+        elif value == RoleEnum.ADMIN.value or value == "admin":
+            return Admin

--- a/tests/factory_fixtures/user.py
+++ b/tests/factory_fixtures/user.py
@@ -11,15 +11,18 @@ def user_attributes(faker):
     def _user_attributes(
         role=None, archived=False, firstName=None, lastName=None, pw=None
     ):
-        return {
+        attrs = {
             "email": faker.unique.email(),
             "password": pw if pw else faker.password(),
             "firstName": firstName if firstName else faker.first_name(),
             "lastName": lastName if lastName else faker.last_name(),
             "phone": faker.phone_number(),
-            "role": role,
             "archived": archived,
         }
+        if role:
+            return {**attrs, "role": role}
+        else:
+            return attrs
 
     yield _user_attributes
 

--- a/tests/integration/test_user_invite.py
+++ b/tests/integration/test_user_invite.py
@@ -2,6 +2,7 @@ import pytest
 from models.user import RoleEnum
 from unittest.mock import patch
 from resources.email import Email
+from models.users.staff import Staff
 
 
 @pytest.mark.usefixtures("client_class", "empty_test_db")
@@ -20,3 +21,18 @@ class TestUserInvite:
         send_user_invite_msg.assert_called()
         assert response.status_code == 201
         assert response.json == {"message": "User Invited"}
+
+    @patch.object(Email, "send_user_invite_msg")
+    def test_invite_user_with_type(
+        self, send_user_invite_msg, valid_header, user_attributes
+    ):
+        response = self.client.post(
+            self.endpoint,
+            headers=valid_header,
+            json={**user_attributes(), "type": "staff"},
+        )
+
+        send_user_invite_msg.assert_called()
+        assert response.status_code == 201
+        assert response.json == {"message": "User Invited"}
+        assert len(Staff.query.all()) == 1


### PR DESCRIPTION
When we switched to STI for users this resource was not updated. I
believe it was assumed that inviting users created PendingUsers, but
this endpoint is actually used to create one of the three types of
users.

Fixes codeforpdx/dwellingly-app/issues/678