### PR TITLE
Implement strategy for unique validations

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -34,11 +34,10 @@ class BaseModel(db.Model):
 
         return obj
 
-    def update(self, schema, payload, context=None):
-        if not context:
-            context = self.validation_context()
-
-        attrs = self.validate(schema, payload, context=context, partial=True)
+    def update(self, schema, payload):
+        attrs = self.validate(
+            schema, payload, context=self.validation_context(), partial=True
+        )
 
         for k, v in attrs.items():
             setattr(self, k, v)

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -12,6 +12,9 @@ class BaseModel(db.Model):
         db.DateTime, onupdate=datetime.utcnow, default=datetime.utcnow, nullable=False
     )
 
+    def validation_context(self):
+        return {}
+
     @classmethod
     def find(cls, id):
         return cls.query.get_or_404(id, f"{cls._name()} not found")
@@ -32,6 +35,9 @@ class BaseModel(db.Model):
         return obj
 
     def update(self, schema, payload, context=None):
+        if not context:
+            context = self.validation_context()
+
         attrs = self.validate(schema, payload, context=context, partial=True)
 
         for k, v in attrs.items():

--- a/models/emergency_contact.py
+++ b/models/emergency_contact.py
@@ -19,6 +19,9 @@ class EmergencyContactModel(BaseModel):
         collection_class=NobiruList,
     )
 
+    def validation_context(self):
+        return {"name": self.name}
+
     def json(self):
         return {
             "id": self.id,

--- a/models/property.py
+++ b/models/property.py
@@ -33,6 +33,9 @@ class PropertyModel(BaseModel):
         collection_class=NobiruList,
     )
 
+    def validation_context(self):
+        return {"name": self.name}
+
     def json(self, include_tenants=False, include_managers=True):
         property = {
             "id": self.id,

--- a/models/user.py
+++ b/models/user.py
@@ -73,6 +73,9 @@ class UserModel(BaseModel):
             bcrypt.gensalt(current_app.config["WORK_FACTOR"]),
         )
 
+    def validation_context(self):
+        return {"email": self.email}
+
     def update_last_active(self):
         self.lastActive = datetime.utcnow()
         db.session.commit()

--- a/resources/property.py
+++ b/resources/property.py
@@ -20,11 +20,7 @@ class Property(Resource):
     def put(self, id):
         property = PropertyModel.find(id)
 
-        return property.update(
-            schema=PropertySchema,
-            context={"name": property.name},
-            payload=request.json,
-        ).json()
+        return property.update(schema=PropertySchema, payload=request.json).json()
 
 
 class Properties(Resource):

--- a/schemas/emergency_contact.py
+++ b/schemas/emergency_contact.py
@@ -12,8 +12,10 @@ class EmergencyContactSchema(ma.SQLAlchemyAutoSchema):
     contact_numbers = fields.List(fields.Nested(ContactNumberSchema), required=True)
 
     @validates("name")
-    def validate_name(self, value):
-        if EmergencyContactModel.find_by_name(value):
+    def validates_uniqueness_of_name(self, value):
+        if self.context.get("name") != value and EmergencyContactModel.find_by_name(
+            value
+        ):
             raise ValidationError(f"{value} is already an emergency contact")
 
     @validates("contact_numbers")

--- a/schemas/property.py
+++ b/schemas/property.py
@@ -27,13 +27,11 @@ class PropertySchema(ma.SQLAlchemyAutoSchema):
 
     @validates("name")
     def validates_uniqueness_of_name(self, value):
-        def _assigning_name():
-            if "name" in self.context and value == self.context["name"]:
-                return False
-            return True
-
-        if _assigning_name() and PropertyModel.find_by_name(value):
+        if self.context.get("name") != value and PropertyModel.find_by_name(value):
             raise ValidationError("A property with this name already exists")
+
+    @validates("name")
+    def validates_prescense_of_name(self, value):
         if blank(value):
             raise ValidationError("Property name cannot be blank")
 

--- a/schemas/property.py
+++ b/schemas/property.py
@@ -31,7 +31,7 @@ class PropertySchema(ma.SQLAlchemyAutoSchema):
             raise ValidationError("A property with this name already exists")
 
     @validates("name")
-    def validates_prescense_of_name(self, value):
+    def validates_presence_of_name(self, value):
         if blank(value):
             raise ValidationError("Property name cannot be blank")
 

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -1,6 +1,7 @@
 from ma import ma
-from models.user import UserModel, RoleEnum
 from marshmallow import fields, validates, ValidationError
+
+from models.user import UserModel, RoleEnum
 
 
 class UserSchema(ma.SQLAlchemyAutoSchema):
@@ -12,7 +13,9 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
 
     @validates("email")
     def validate_uniqueness_of_email(self, value):
-        if UserModel.find_by_email(value):
+        if self.context.get("email") == value:
+            return
+        elif UserModel.find_by_email(value):
             raise ValidationError(f"A user with email '{value}' already exists")
 
     def get_role_value(self, obj):

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -13,9 +13,7 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
 
     @validates("email")
     def validate_uniqueness_of_email(self, value):
-        if self.context.get("email") == value:
-            return
-        elif UserModel.find_by_email(value):
+        if self.context.get("email") != value and UserModel.find_by_email(value):
             raise ValidationError(f"A user with email '{value}' already exists")
 
     def get_role_value(self, obj):

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -46,7 +46,6 @@ class TestPropertyPut:
 
         mock_update.assert_called_once_with(
             schema=PropertySchema,
-            context={"name": property.name},
             payload={"num_units": 2},
         )
         assert response.status_code == 200

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -132,7 +132,9 @@ class TestUser:
         payload = {"role": RoleEnum.ADMIN.value}
         self.client.patch(f"api/user/{id}", json=payload, headers=valid_header)
 
-        assert Admin.find(id).role == RoleEnum.ADMIN
+        user = Admin.find(id)
+        assert user.role == RoleEnum.ADMIN
+        assert user.type == "admin"
 
 
 @pytest.mark.usefixtures("client_class", "empty_test_db")

--- a/tests/schemas/test_property_schema.py
+++ b/tests/schemas/test_property_schema.py
@@ -93,9 +93,8 @@ class TestPostLoadDeserialization:
         pm_2 = create_property_manager()
         pm_3 = create_property_manager()
         payload = {"propertyManagerIDs": [pm_2.id, pm_3.id]}
-        context = {"name": property.name}
 
-        property.update(schema=PropertySchema, context=context, payload=payload)
+        property.update(schema=PropertySchema, payload=payload)
         db.session.rollback()
 
         assert property.managers == [pm_2, pm_3]

--- a/tests/unit/base_interface_test.py
+++ b/tests/unit/base_interface_test.py
@@ -59,7 +59,9 @@ class BaseInterfaceTest:
         with patch.object(self.object, "validate", return_value={}) as mock_validate:
             response = self.object.update(schema=self.schema, payload={})
 
-        mock_validate.assert_called_with(self.schema, {}, context=None, partial=True)
+        mock_validate.assert_called_with(
+            self.schema, {}, context=self.object.validation_context(), partial=True
+        )
         mock_session.add.assert_called_with(self.object)
         mock_session.commit.assert_called()
 


### PR DESCRIPTION
## Description

Avoid the false positives when validating a unique field. 
Uses Anthony's context implementation to pass the original value of fields, except the context is assigned automatically. It just needs to be explicitly set in the model, and then it will be available in the schema's for validations.

Refactored the app, and implemented this on all unique fields.

Fixes codeforpdx/dwellingly-app/issues/709
