### PR TITLE
Remove url helper4 emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,6 @@ PYTHONPATH=${PWD}:${PYTHONPATH}
 ## Uncomment to see logging from sqlalchemy
 # DB_LOGGING=ON
 
-## Uncomment to set front end base url
-#FRONTEND_BASE_URL="https://localhost:3000"
-
 ## To set the database to postgresql. Uncomment the env vars below
 # To set the database to postgresql. Uncomment the env vars below
 # DEV_DATABASE_URL=postgresql://localhost/dwellingly_development

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ PYTHONPATH=${PWD}:${PYTHONPATH}
 ## Uncomment to see logging from sqlalchemy
 # DB_LOGGING=ON
 
+## Uncomment to set front end base url
+#FRONTEND_BASE_URL=https://localhost:3000
+
 ## To set the database to postgresql. Uncomment the env vars below
 # DEV_DATABASE_URL=postgresql://localhost/dwellingly_development
 # TEST_DATABASE_URL=postgresql://localhost/dwellingly_test

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,9 @@ PYTHONPATH=${PWD}:${PYTHONPATH}
 # DB_LOGGING=ON
 
 ## Uncomment to set front end base url
-#FRONTEND_BASE_URL=https://localhost:3000
+#FRONTEND_BASE_URL="https://localhost:3000"
 
 ## To set the database to postgresql. Uncomment the env vars below
+# To set the database to postgresql. Uncomment the env vars below
 # DEV_DATABASE_URL=postgresql://localhost/dwellingly_development
 # TEST_DATABASE_URL=postgresql://localhost/dwellingly_test

--- a/config/environment.py
+++ b/config/environment.py
@@ -23,7 +23,7 @@ class Default(object):
     MAIL_DEFAULT_SENDER = os.environ.get("MAIL_DEFAULT_SENDER")
 
     # Default front end url
-    FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL")
+    FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL", "http://localhost:3000")
 
     # Configure JWT error message key
     JWT_ERROR_MESSAGE_KEY = "message"
@@ -48,9 +48,6 @@ class Testing(Default):
     JWT_ACCESS_TOKEN_EXPIRES = False
     JWT_REFRESH_TOKEN_EXPIRES = False
     CORS_ORIGINS = ["*"]
-
-    # Override default url for testing
-    FRONTEND_BASE_URL = "https://localhost:3000"
 
 
 class Production(Default):

--- a/config/environment.py
+++ b/config/environment.py
@@ -49,6 +49,9 @@ class Testing(Default):
     JWT_REFRESH_TOKEN_EXPIRES = False
     CORS_ORIGINS = ["*"]
 
+    # Override default url for testing
+    FRONTEND_BASE_URL = "https://localhost:3000"
+
 
 class Production(Default):
     # Heroku hack to connect to postgres dialect since sqlalchemy does things differently. # noqa

--- a/config/environment.py
+++ b/config/environment.py
@@ -22,6 +22,9 @@ class Default(object):
     MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD")
     MAIL_DEFAULT_SENDER = os.environ.get("MAIL_DEFAULT_SENDER")
 
+    # Default front end url
+    FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL")
+
     # Configure JWT error message key
     JWT_ERROR_MESSAGE_KEY = "message"
 

--- a/resources/email.py
+++ b/resources/email.py
@@ -1,4 +1,5 @@
 from flask import render_template
+from flask import current_app as app
 from flask_mailman import EmailMultiAlternatives
 
 
@@ -9,16 +10,27 @@ class Email:
     @staticmethod
     def send_reset_password_msg(user):
         token = user.reset_password_token()
+        FRONTEND_BASE_URL = app.config["FRONTEND_BASE_URL"]
         msg = EmailMultiAlternatives(
-            "Rest password for Dwellingly",
-            render_template("emails/reset_msg.html", user=user, token=token),
+            "Reset password for Dwellingly",
+            render_template(
+                "emails/reset_msg.html",
+                FRONTEND_BASE_URL=FRONTEND_BASE_URL,
+                user=user,
+                token=token,
+            ),
             Email.NO_REPLY,
             [user.email],
         )
         msg.content_subtype = "html"
 
         msg.attach_alternative(
-            render_template("emails/reset_msg.txt", user=user, token=token),
+            render_template(
+                "emails/reset_msg.txt",
+                FRONTEND_BASE_URL=FRONTEND_BASE_URL,
+                user=user,
+                token=token,
+            ),
             "text/plain",
         )
 
@@ -27,15 +39,26 @@ class Email:
     @staticmethod
     def send_user_invite_msg(user):
         token = user.reset_password_token()
+        FRONTEND_BASE_URL = app.config["FRONTEND_BASE_URL"]
         msg = EmailMultiAlternatives(
             "Create Your Dwellingly Account",
-            render_template("emails/invite_user_msg.html", user=user, token=token),
+            render_template(
+                "emails/invite_user_msg.html",
+                FRONTEND_BASE_URL=FRONTEND_BASE_URL,
+                user=user,
+                token=token,
+            ),
             Email.NO_REPLY,
             [user.email],
         )
         msg.content_subtype = "html"
         msg.attach_alternative(
-            render_template("emails/invite_user_msg.txt", user=user, token=token),
+            render_template(
+                "emails/invite_user_msg.txt",
+                FRONTEND_BASE_URL=FRONTEND_BASE_URL,
+                user=user,
+                token=token,
+            ),
             "text/plain",
         )
         msg.send()

--- a/templates/emails/invite_user_msg.html
+++ b/templates/emails/invite_user_msg.html
@@ -2,11 +2,15 @@
 
 <p>You have been invited to the Dwellingly Platform!</p>
 
-<p>To finish creating your account, please set up your password here: <a href="{{ url_for('resetpassword', token=token, _method='GET', _external=True) }}"> Reset password link</a></p>
+<p>To finish creating your account, please set up your password here: <a
+                                                                          href="{{
+                                                                          FRONTEND_BASE_URL
+                                                                          }}/changePassword?token={{token}}"> Reset password link</a></p>
 
 <p>This link will expire in 10 minutes.</p>
 
-<p>Alternatively, you can paste the following link in your browser's address bar: {{ url_for('resetpassword', token=token, _method='GET', _external=True) }}</p>
+<p>Alternatively, you can paste the following link in your browser's address
+bar: {{ FRONTEND_BASE_URL }}/changePassword?token={{token}}</p>
 
 
 <p>Best,</p>

--- a/templates/emails/invite_user_msg.txt
+++ b/templates/emails/invite_user_msg.txt
@@ -4,7 +4,7 @@ You have been invited to the Dwellingly Platform!
 
 To finish creating your account, please reset your password at the following link:
 
-{{ url_for('resetpassword', token=token, _method='GET', _external=True) }}
+{{ FRONTEND_BASE_URL }}/changePassword?token={{token}}
 
 Best,
 Team Dwellingly.

--- a/templates/emails/reset_msg.html
+++ b/templates/emails/reset_msg.html
@@ -2,10 +2,10 @@
 
 <p>To reset your password click on the following link:
 
-<a href="{{ url_for('resetpassword', token=token, _method='GET', _external=True) }}"> Reset password link</a></p>
+<a href="{{ FRONTEND_BASE_URL }}/changePassword?token={{token}}"> Reset password link</a></p>
 
 <p>Alternatively, you can paste the following link in your browser's address bar:</p>
-<p>{{ url_for('resetpassword', token=token, _method='GET', _external=True) }}</p>
+<p>{{ FRONTEND_BASE_URL }}/changePassword?token={{token}}</p>
 <p> If you have not requested a password reset simply ignore this message.</p>
 
 

--- a/templates/emails/reset_msg.txt
+++ b/templates/emails/reset_msg.txt
@@ -2,7 +2,7 @@ Hello {{ user.firstName }},
 
 To reset your password click on the following link:
 
-{{ url_for('resetpassword', token=token, _method='GET', _external=True) }}
+{{ FRONTEND_BASE_URL }}/changePassword?token={{ token }}
 
 If you have not requested a password reset simply ignore this message.
 

--- a/tests/authorizations/test_property_authorization.py
+++ b/tests/authorizations/test_property_authorization.py
@@ -32,7 +32,7 @@ class TestPropertyAuthorizations:
         assert responseNoAdmin == 401
         assert responseNoAdmin.json == {"message": "Missing authorization header"}
 
-    def test_archive_properties_non_admin(self, staff_header):
+    def test_archive_properties_non_admin(self, create_property, staff_header):
         """The server responds with a 401 error if a non-admin tries to archive"""
         responseNoAdmin = self.client.patch(
             "/api/properties/archive", json={}, headers=staff_header()

--- a/tests/authorizations/test_property_authorization.py
+++ b/tests/authorizations/test_property_authorization.py
@@ -32,7 +32,7 @@ class TestPropertyAuthorizations:
         assert responseNoAdmin == 401
         assert responseNoAdmin.json == {"message": "Missing authorization header"}
 
-    def test_archive_properties_non_admin(self, create_property, staff_header):
+    def test_archive_properties_non_admin(self, staff_header):
         """The server responds with a 401 error if a non-admin tries to archive"""
         responseNoAdmin = self.client.patch(
             "/api/properties/archive", json={}, headers=staff_header()

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -31,3 +31,10 @@ class TestEmailTemplateRender:
                 link = "{}/changePassword?token={}".format(FRONTEND_BASE_URL, token)
 
                 assert link in email
+
+    def test_hyperlink_is_https(self):
+        app = create_app(os.getenv("FLASK_ENV"))
+
+        with app.app_context():
+            FRONTEND_BASE_URL = app.config["FRONTEND_BASE_URL"]
+            assert FRONTEND_BASE_URL.startswith("https://")

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -1,0 +1,33 @@
+from app import create_app
+import os
+from flask import render_template
+
+
+class TestEmailTemplateRender:
+    def test_reset_password_html_msg(self, user_attributes):
+        user = user_attributes()
+        # need to find a user fixture and a token fixture
+        token = "fake-token"
+        app = create_app(os.getenv("FLASK_ENV"))
+        templates = [
+            "emails/reset_msg.html",
+            "emails/reset_msg.txt",
+            "emails/invite_user_msg.html",
+            "emails/invite_user_msg.txt",
+        ]
+
+        with app.app_context():
+            FRONTEND_BASE_URL = app.config["FRONTEND_BASE_URL"]
+
+            for template in templates:
+
+                email = render_template(
+                    template,
+                    FRONTEND_BASE_URL=FRONTEND_BASE_URL,
+                    user=user,
+                    token=token,
+                )
+
+                link = "{}/changePassword?token={}".format(FRONTEND_BASE_URL, token)
+
+                assert link in email

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -4,9 +4,12 @@ from flask import render_template
 
 
 class TestEmailTemplateRender:
+
+    FRONTEND_BASE_URL = "http://localhost:3000"
+
     def test_reset_password_html_msg(self, user_attributes):
         user = user_attributes()
-        # need to find a user fixture and a token fixture
+
         token = "fake-token"
         app = create_app(os.getenv("FLASK_ENV"))
         templates = [
@@ -17,19 +20,15 @@ class TestEmailTemplateRender:
         ]
 
         with app.app_context():
-            FRONTEND_BASE_URL = app.config["FRONTEND_BASE_URL"]
-
             for template in templates:
-
                 email = render_template(
                     template,
-                    FRONTEND_BASE_URL=FRONTEND_BASE_URL,
+                    FRONTEND_BASE_URL=self.FRONTEND_BASE_URL,
                     user=user,
                     token=token,
                 )
 
-                link = "{}/changePassword?token={}".format(FRONTEND_BASE_URL, token)
-
+                link = "http://localhost:3000/changePassword?token={}".format(token)
                 assert link in email
 
     def test_hyperlink_is_https(self):
@@ -37,4 +36,4 @@ class TestEmailTemplateRender:
 
         with app.app_context():
             FRONTEND_BASE_URL = app.config["FRONTEND_BASE_URL"]
-            assert FRONTEND_BASE_URL.startswith("https://")
+            assert FRONTEND_BASE_URL.startswith("http://")


### PR DESCRIPTION
## Description
Remove ```url_for``` from email templates. Replaced with an app configuration variable ```FRONTEND_BASE_URL```. 
### What issue is this solving?
<!-- replace ### with the issue number. This will ensure the issue in the FE repo is automatically closed when the PR is merged. -->
Closes codeforpdx/dwellingly-app/issues/461
