### PR TITLE
Switch to has_one relationship for tenant/lease

### DIFF
--- a/models/lease.py
+++ b/models/lease.py
@@ -1,4 +1,3 @@
-from sqlalchemy.sql.functions import now
 from db import db
 from models.base_model import BaseModel
 from utils.time import Time
@@ -10,7 +9,9 @@ class LeaseModel(BaseModel):
 
     id = db.Column(db.Integer, primary_key=True)
     propertyID = db.Column(db.Integer, db.ForeignKey("properties.id"), nullable=False)
-    tenantID = db.Column(db.Integer, db.ForeignKey("tenants.id"), nullable=False)
+    tenantID = db.Column(
+        db.Integer, db.ForeignKey("tenants.id"), unique=True, nullable=False
+    )
     occupants = db.Column(db.Integer)
     dateTimeStart = db.Column(db.DateTime, nullable=False)
     dateTimeEnd = db.Column(db.DateTime, nullable=False)
@@ -30,8 +31,3 @@ class LeaseModel(BaseModel):
     def is_active(self):
         now = datetime.now()
         return now > self.dateTimeStart and now < self.dateTimeEnd
-
-    @classmethod
-    def active(cls):
-        time = now()
-        return (time > cls.dateTimeStart) & (time < cls.dateTimeEnd)

--- a/models/tenant.py
+++ b/models/tenant.py
@@ -22,12 +22,11 @@ class TenantModel(BaseModel):
         collection_class=NobiruList,
     )
 
-    leases = db.relationship(
-        "LeaseModel",
+    lease = db.relationship(
+        LeaseModel,
         backref="tenant",
-        lazy="dynamic",
         cascade="all, delete-orphan",
-        collection_class=NobiruList,
+        uselist=False,
     )
 
     tickets = db.relationship(
@@ -35,15 +34,13 @@ class TenantModel(BaseModel):
     )
 
     def json(self):
-        first_active_lease = self.leases.filter(LeaseModel.active()).first()
-        active_lease_json = first_active_lease.json() if first_active_lease else ""
         return {
             "id": self.id,
             "firstName": self.firstName,
             "lastName": self.lastName,
             "fullName": "{} {}".format(self.firstName, self.lastName),
             "phone": self.phone,
-            "lease": active_lease_json,
+            "lease": self.lease.json() if self.lease else None,
             "staff": self.staff.json(),
             "created_at": Time.format_date(self.created_at),
             "updated_at": Time.format_date(self.updated_at),

--- a/resources/tenants.py
+++ b/resources/tenants.py
@@ -40,9 +40,9 @@ class Tenants(Resource):
                 params[param] = request.json.get(param)
 
         if set(valid_lease_params) & set(list(request.json)):
-            params["leases"] = [{}]
+            params["lease"] = {}
         for param in valid_lease_params:
             if request.json.get(param):
-                params["leases"][0][param] = request.json.get(param)
+                params["lease"][param] = request.json.get(param)
 
         return params

--- a/schemas/tenant.py
+++ b/schemas/tenant.py
@@ -14,7 +14,7 @@ class TenantSchema(ma.SQLAlchemyAutoSchema):
     updated_at = fields.DateTime(time_format)
 
     staffIDs = fields.List(fields.Integer(), required=False)
-    leases = fields.List(fields.Nested("BuildLeaseSchema"))
+    lease = fields.Nested("BuildLeaseSchema")
 
     firstName = fields.Str(
         required=True,

--- a/tests/integration/test_tenants.py
+++ b/tests/integration/test_tenants.py
@@ -68,7 +68,7 @@ class TestTenantsPost:
             )
 
         mock_create.assert_called_once_with(
-            schema=TenantSchema, payload={**tenant_attrs, "leases": [{**lease_attrs}]}
+            schema=TenantSchema, payload={**tenant_attrs, "lease": {**lease_attrs}}
         )
 
         assert response.json == tenant.json()

--- a/tests/serializers/tenant/test_tenant_serializer.py
+++ b/tests/serializers/tenant/test_tenant_serializer.py
@@ -13,7 +13,7 @@ class TestTenantSerializer:
             "id": tenant.id,
             "lastName": tenant.lastName,
             "phone": tenant.phone,
-            "leases": [],
+            "lease": None,
             "created_at": Time.format_date(tenant.created_at),
             "updated_at": Time.format_date(tenant.updated_at),
             "archived": tenant.archived,

--- a/tests/unit/test_tenant.py
+++ b/tests/unit/test_tenant.py
@@ -1,10 +1,8 @@
 import pytest
 from tests.unit.base_interface_test import BaseInterfaceTest
-from models.property import PropertyModel
 from models.tenant import TenantModel
 from schemas.tenant import TenantSchema
 from utils.time import Time
-import datetime
 
 
 class TestBaseTenantModel(BaseInterfaceTest):
@@ -16,28 +14,6 @@ class TestBaseTenantModel(BaseInterfaceTest):
 
 @pytest.mark.usefixtures("empty_test_db")
 class TestTenantModel:
-    def test_only_active_lease_returned(self, faker, create_lease, create_tenant):
-        tenant = create_tenant()
-
-        # Create an expired lease for the tenant
-        lease_expired_end = faker.date_time_this_decade(
-            before_now=True, after_now=False
-        )
-        lease_expired_start = lease_expired_end - datetime.timedelta(days=365)
-        lease_expired = create_lease(
-            tenant=tenant,
-            dateTimeStart=lease_expired_start,
-            dateTimeEnd=lease_expired_end,
-        )
-
-        # Create an active lease for the tenant
-        lease_active = create_lease(
-            tenant=tenant, property=PropertyModel.find(lease_expired.propertyID)
-        )
-
-        # Active lease should be the only one that shows up
-        assert tenant.json()["lease"] == lease_active.json()
-
     def test_json(self, create_tenant, create_lease):
         tenant = create_tenant()
         lease = create_lease(tenant=tenant)


### PR DESCRIPTION
Updates to use a has_one relationship. Tenant has one lease.

This is done by defining the tenant_id field on the Lease table
to be unique so that only one lease record can be inserted for a tenant,
and by changing the relationship not to return a collection object.
