### PR TITLE
Fix create tenant param format being received by the backend

### DIFF
--- a/resources/tenants.py
+++ b/resources/tenants.py
@@ -32,25 +32,6 @@ class Tenants(Resource):
     @admin_required
     def post(self):
         return (
-            TenantModel.create(
-                schema=TenantSchema, payload=self._build_payload()
-            ).json(),
+            TenantModel.create(schema=TenantSchema, payload=request.json).json(),
             201,
         )
-
-    def _build_payload(self):
-        valid_tenant_params = ["firstName", "lastName", "phone", "staffIDs"]
-        valid_lease_params = ["dateTimeEnd", "dateTimeStart", "propertyID"]
-
-        params = {}
-        for param in valid_tenant_params:
-            if request.json.get(param):
-                params[param] = request.json.get(param)
-
-        if set(valid_lease_params) & set(list(request.json)):
-            params["lease"] = {}
-        for param in valid_lease_params:
-            if request.json.get(param):
-                params["lease"][param] = request.json.get(param)
-
-        return params

--- a/tests/attributes.py
+++ b/tests/attributes.py
@@ -25,7 +25,7 @@ def emergency_contact_attrs(faker):
 def property_attrs(faker, archived=False):
     return {
         "name": faker.unique.company(),
-        "address": faker.address(),
+        "address": faker.street_address(),
         "city": faker.city(),
         "num_units": faker.random_int(min=1),
         "state": faker.state(),

--- a/tests/integration/test_tenants.py
+++ b/tests/integration/test_tenants.py
@@ -59,17 +59,16 @@ class TestTenantsPost:
         tenant_attrs = tenant_attributes()
         lease_attrs = lease_payload()
         tenant = create_tenant()
+        payload = {**tenant_attrs, "lease": {**lease_attrs}}
 
         with patch.object(TenantModel, "create", return_value=tenant) as mock_create:
             response = self.client.post(
                 "/api/tenants",
-                json={**tenant_attrs, **lease_attrs},
+                json=payload,
                 headers=valid_header,
             )
 
-        mock_create.assert_called_once_with(
-            schema=TenantSchema, payload={**tenant_attrs, "lease": {**lease_attrs}}
-        )
+        mock_create.assert_called_once_with(schema=TenantSchema, payload=payload)
 
         assert response.json == tenant.json()
         assert response.status_code == 201


### PR DESCRIPTION
This fix was mostly done on the frontend. Frontend needed to send a
correctly formatted tenant object payload that includes a lease if the
tenant is being created with a lease.

Fixes codeforpdx/dwellingly-app/issues/693

