### PR TITLE
Cascade note deletion when the ticket is deleted

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ import jwt
 from flask import current_app
 from app import create_app
 
+from db import db
 from data.seed import Seed
 from tests.factory_fixtures import *  # noqa: F401, F403
 
@@ -17,6 +18,14 @@ def app(monkeypatch):
     monkeypatch.setenv("FLASK_ENV", "testing")
     app = create_app("testing")
     return app
+
+
+@pytest.fixture(scope="session", autouse=True)
+def db_setup():
+    app = create_app("testing")
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
 
 
 @pytest.fixture(autouse=True)

--- a/models/notes.py
+++ b/models/notes.py
@@ -9,7 +9,9 @@ class NotesModel(BaseModel):
     id = db.Column(db.Integer, primary_key=True)
     text = db.Column(db.Text)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
-    ticket_id = db.Column(db.Integer, db.ForeignKey("tickets.id"), nullable=False)
+    ticket_id = db.Column(
+        db.Integer, db.ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False
+    )
 
     def json(self):
 

--- a/tests/integration/test_tickets.py
+++ b/tests/integration/test_tickets.py
@@ -88,13 +88,16 @@ class TestTicketsPOST(BaseConfig):
 
 
 class TestTicketsDELETE(BaseConfig):
-    def test_delete_many(self, valid_header, create_ticket):
-        ticket_1 = create_ticket()
-        ticket_2 = create_ticket()
-        delete_ids = {"ids": [ticket_1.id, ticket_2.id]}
+    def test_delete_many(self, valid_header, create_note):
+        note_1 = create_note()
+        note_2 = create_note()
+        ticket_1 = note_1.ticket
+        ticket_2 = note_2.ticket
 
         response = self.client.delete(
-            self.endpoint, json=delete_ids, headers=valid_header
+            self.endpoint,
+            json={"ids": [ticket_1.id, ticket_2.id]},
+            headers=valid_header,
         )
         db.session.rollback()
 


### PR DESCRIPTION
There is a batch ticket deletion in the ticket resource. This batch deletion goes straight to the database, and app logic for cascade deletion does not happen. on cascade delete must be set directly on the db layer in order to delete cascade with the batch delete function.

Fixes codeforpdx/dwellingly-app/issues/762